### PR TITLE
feat(clipboard): redesign toolbar as fixed header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId = "com.orion.kboard"
-        minSdk = 31
+        minSdk = 23
         targetSdk = 36
         versionCode = providers.of(GitCommitCountValueSource::class.java) {}.get()
         versionName = "2.5.6"

--- a/app/src/main/java/helium314/keyboard/keyboard/AccessPointMenuView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/AccessPointMenuView.kt
@@ -39,6 +39,7 @@ import helium314.keyboard.latin.utils.getPinnedToolbarKeys
 import helium314.keyboard.latin.utils.getStringResourceOrName
 import helium314.keyboard.latin.utils.getToolbarKeyFromDragData
 import helium314.keyboard.latin.utils.removePinnedKey
+import helium314.keyboard.latin.utils.startDragAndDropCompat
 
 class AccessPointMenuView @JvmOverloads constructor(
     context: Context,
@@ -162,7 +163,11 @@ class AccessPointMenuView @JvmOverloads constructor(
                 val clipData = ClipData.newPlainText(TOOLBAR_DRAG_CLIP_LABEL, key.name)
                 val shadow = DragShadowBuilder(v)
                 v.visibility = View.INVISIBLE
-                v.startDragAndDrop(clipData, shadow, ToolbarDragState(key, ToolbarDragSource.ACCESS_POINT_MENU, v), 0)
+                v.startDragAndDropCompat(
+                    clipData,
+                    shadow,
+                    ToolbarDragState(key, ToolbarDragSource.ACCESS_POINT_MENU, v),
+                )
                 true
             }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -1074,6 +1074,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (mAccessPointMenuView != null) {
             mAccessPointMenuView.setVisibility(View.GONE);
         }
+        if (mSuggestionStripView != null) {
+            mSuggestionStripView.setAccessPointMenuOpen(false);
+        }
         setKeyboardPanelOffsets((mKlipyPalettesView != null && mKlipyPalettesView.isSearchMode())
                 || (mEmojiPalettesView != null && mEmojiPalettesView.isSearchMode()));
         updatePersistentEmojiRow();
@@ -1111,6 +1114,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                 if (mAccessPointMenuView != null) {
                     mAccessPointMenuView.setVisibility(View.GONE);
                 }
+                if (mSuggestionStripView != null) {
+                    mSuggestionStripView.setAccessPointMenuOpen(false);
+                }
                 updatePersistentEmojiRow();
                 if (mCurrentInputView != null)
                     mCurrentInputView.requestLayout();
@@ -1136,11 +1142,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                         mKeyboardView.getKeyVisualAttribute(),
                         mLatinIME.getCurrentInputEditorInfo(), mLatinIME.mKeyboardActionListener);
                 mClipboardHistoryView.setVisibility(View.VISIBLE);
-                mStripContainer.setVisibility(getSecondaryStripVisibility());
+                mStripContainer.setVisibility(View.GONE);
                 setKeyboardPanelOffsets(true);
-                mClipboardStripScrollView
-                        .post(() -> mClipboardStripScrollView.fullScroll(HorizontalScrollView.FOCUS_RIGHT));
-                mClipboardStripScrollView.setVisibility(View.VISIBLE);
+                mClipboardStripScrollView.setVisibility(View.GONE);
 
                 mEmojiTabStripView.setVisibility(View.GONE);
                 mSuggestionStripView.setVisibility(View.GONE);
@@ -1151,6 +1155,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                 }
                 if (mAccessPointMenuView != null) {
                     mAccessPointMenuView.setVisibility(View.GONE);
+                }
+                if (mSuggestionStripView != null) {
+                    mSuggestionStripView.setAccessPointMenuOpen(false);
                 }
                 updatePersistentEmojiRow();
                 if (mCurrentInputView != null)
@@ -1191,6 +1198,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                 if (mAccessPointMenuView != null) {
                     mAccessPointMenuView.setVisibility(View.GONE);
                 }
+                if (mSuggestionStripView != null) {
+                    mSuggestionStripView.setAccessPointMenuOpen(false);
+                }
                 updatePersistentEmojiRow();
                 if (mCurrentInputView != null)
                     mCurrentInputView.requestLayout();
@@ -1230,6 +1240,9 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
                 }
                 if (mAccessPointMenuView != null) {
                     mAccessPointMenuView.setVisibility(View.GONE);
+                }
+                if (mSuggestionStripView != null) {
+                    mSuggestionStripView.setAccessPointMenuOpen(false);
                 }
                 updatePersistentEmojiRow();
                 if (mCurrentInputView != null)

--- a/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/clipboard/ClipboardHistoryView.kt
@@ -5,40 +5,44 @@ package helium314.keyboard.keyboard.clipboard
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.RippleDrawable
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.graphics.ColorUtils
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import helium314.keyboard.event.HapticEvent
 import helium314.keyboard.keyboard.KeyboardActionListener
 import helium314.keyboard.keyboard.KeyboardId
 import helium314.keyboard.keyboard.KeyboardLayoutSet
-import helium314.keyboard.keyboard.KeyboardSwitcher
 import helium314.keyboard.keyboard.KeyboardTypeface
 import helium314.keyboard.keyboard.MainKeyboardView
 import helium314.keyboard.keyboard.PointerTracker
 import helium314.keyboard.keyboard.internal.KeyDrawParams
 import helium314.keyboard.keyboard.internal.KeyVisualAttributes
+import helium314.keyboard.keyboard.internal.KeyboardIconsSet
 import helium314.keyboard.keyboard.internal.keyboard_parser.floris.KeyCode
 import helium314.keyboard.latin.AudioAndHapticFeedbackManager
 import helium314.keyboard.latin.ClipboardHistoryManager
 import helium314.keyboard.latin.R
+import helium314.keyboard.latin.common.Colors
 import helium314.keyboard.latin.common.ColorType
 import helium314.keyboard.latin.common.Constants
 import helium314.keyboard.latin.database.ClipboardDao
 import helium314.keyboard.latin.settings.Settings
 import helium314.keyboard.latin.utils.ResourceUtils
 import helium314.keyboard.latin.utils.ToolbarKey
-import helium314.keyboard.latin.utils.createToolbarKey
-import helium314.keyboard.latin.utils.getCodeForToolbarKey
-import helium314.keyboard.latin.utils.getCodeForToolbarKeyLongClick
-import helium314.keyboard.latin.utils.getEnabledClipboardToolbarKeys
+import helium314.keyboard.latin.utils.dpToPx
 import helium314.keyboard.latin.utils.prefs
-import helium314.keyboard.latin.utils.setToolbarButtonsActivatedStateOnPrefChange
 
 @SuppressLint("CustomViewStyleable")
 class ClipboardHistoryView @JvmOverloads constructor(
@@ -47,7 +51,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
         defStyle: Int = R.attr.clipboardHistoryViewStyle
 ) : LinearLayout(context, attrs, defStyle), View.OnClickListener,
     ClipboardDao.Listener, OnKeyEventListener,
-    View.OnLongClickListener, SharedPreferences.OnSharedPreferenceChangeListener {
+    SharedPreferences.OnSharedPreferenceChangeListener {
 
     private val clipboardLayoutParams = ClipboardLayoutParams(context)
     private val pinIconId: Int
@@ -55,7 +59,9 @@ class ClipboardHistoryView @JvmOverloads constructor(
 
     private lateinit var clipboardRecyclerView: ClipboardHistoryRecyclerView
     private lateinit var placeholderView: TextView
-    private val toolbarKeys = mutableListOf<ImageButton>()
+    private lateinit var backButton: ImageButton
+    private lateinit var clearButton: ImageButton
+    private lateinit var titleView: TextView
     private lateinit var clipboardAdapter: ClipboardAdapter
 
     lateinit var keyboardActionListener: KeyboardActionListener
@@ -70,10 +76,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
         val keyboardViewAttr = context.obtainStyledAttributes(attrs, R.styleable.KeyboardView, defStyle, R.style.KeyboardView)
         keyBackgroundId = keyboardViewAttr.getResourceId(R.styleable.KeyboardView_keyBackground, 0)
         keyboardViewAttr.recycle()
-        if (Settings.getValues().mSecondaryStripVisible) {
-            getEnabledClipboardToolbarKeys(context.prefs())
-                .forEach { toolbarKeys.add(createToolbarKey(context, it)) }
-        }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -81,20 +83,22 @@ class ClipboardHistoryView @JvmOverloads constructor(
         val abcHeight = ResourceUtils.getKeyboardHeight(resources, settings)
         val persistentEmojiEnabled = context.prefs().getBoolean(Settings.PREF_PERSISTENT_EMOJI_ROW, helium314.keyboard.latin.settings.Defaults.PREF_PERSISTENT_EMOJI_ROW)
         val emojiRowHeight = if (persistentEmojiEnabled) (41 * resources.displayMetrics.density).toInt() else 0
-        val finalHeight = abcHeight + emojiRowHeight + paddingTop + paddingBottom - (6 * resources.displayMetrics.density).toInt() + 1
+        val toolbarHeight = resources.getDimensionPixelSize(R.dimen.config_suggestions_strip_height)
+        val finalHeight = abcHeight + emojiRowHeight + toolbarHeight + paddingTop + paddingBottom - (6 * resources.displayMetrics.density).toInt() + 1
         super.onMeasure(widthMeasureSpec, MeasureSpec.makeMeasureSpec(finalHeight, MeasureSpec.EXACTLY))
         setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), finalHeight)
     }
 
-    @SuppressLint("ClickableViewAccessibility")
-    private fun initialize() { // needs to be delayed for access to ClipboardStrip, which is not a child of this view
+    private fun initialize() {
         if (this::clipboardAdapter.isInitialized) return
-        val colors = Settings.getValues().mColors
         clipboardAdapter = ClipboardAdapter(clipboardLayoutParams, this).apply {
             itemBackgroundId = keyBackgroundId
             pinnedIconResId = pinIconId
         }
         placeholderView = findViewById(R.id.clipboard_empty_view)
+        titleView = findViewById(R.id.clipboard_title)
+        backButton = findViewById(R.id.clipboard_back_button)
+        clearButton = findViewById(R.id.clipboard_clear_button)
         clipboardRecyclerView = findViewById<ClipboardHistoryRecyclerView>(R.id.clipboard_list).apply {
             val colCount = resources.getInteger(R.integer.config_clipboard_keyboard_col_count)
             layoutManager = StaggeredGridLayoutManager(colCount, StaggeredGridLayoutManager.VERTICAL)
@@ -102,14 +106,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
             persistentDrawingCache = PERSISTENT_NO_CACHE
             clipboardLayoutParams.setListProperties(this)
             placeholderView = this@ClipboardHistoryView.placeholderView
-        }
-        val clipboardStrip = KeyboardSwitcher.getInstance().clipboardStrip
-        toolbarKeys.forEach {
-            clipboardStrip.addView(it)
-            it.setOnClickListener(this@ClipboardHistoryView)
-            it.setOnLongClickListener(this@ClipboardHistoryView)
-            colors.setColor(it, ColorType.TOOL_BAR_KEY)
-            colors.setBackground(it, ColorType.STRIP_BACKGROUND)
         }
     }
 
@@ -122,10 +118,42 @@ class ClipboardHistoryView @JvmOverloads constructor(
         }
     }
 
-    private fun setupToolbarKeys() {
-        // set layout params
-        val toolbarKeyLayoutParams = LayoutParams(resources.getDimensionPixelSize(R.dimen.config_suggestions_strip_edge_key_width), LayoutParams.MATCH_PARENT)
-        toolbarKeys.forEach { it.layoutParams = toolbarKeyLayoutParams }
+    private fun setupHeader() {
+        val colors = Settings.getValues().mColors
+        KeyboardTypeface.applyToTextView(
+            titleView,
+            titleView.text,
+            android.graphics.Typeface.defaultFromStyle(android.graphics.Typeface.BOLD)
+        )
+        titleView.setTextColor(colors.get(ColorType.KEY_TEXT))
+
+        setupHeaderButton(backButton, colors)
+        backButton.setOnClickListener(this)
+
+        setupHeaderButton(clearButton, colors)
+        clearButton.setImageDrawable(KeyboardIconsSet.instance.getNewDrawable(ToolbarKey.CLEAR_CLIPBOARD.name, context))
+        clearButton.setOnClickListener(this)
+    }
+
+    private fun setupHeaderButton(button: ImageButton, colors: Colors) {
+        button.imageTintList = ColorStateList.valueOf(colors.get(ColorType.KEY_TEXT))
+        button.background = createHeaderButtonBackground(colors)
+        button.setPadding(0, 0, 0, 0)
+        button.scaleType = ImageView.ScaleType.CENTER
+    }
+
+    private fun createHeaderButtonBackground(colors: Colors): RippleDrawable {
+        val shape = GradientDrawable().apply {
+            shape = GradientDrawable.OVAL
+            setColor(Color.WHITE)
+            colors.setColor(this, ColorType.SPECIAL_KEY_BACKGROUND)
+        }
+        val rippleColor = ColorStateList.valueOf(
+            ColorUtils.setAlphaComponent(colors.get(ColorType.FUNCTIONAL_KEY_TEXT), 0x33)
+        )
+        val inset = 3.dpToPx(resources)
+        val content = InsetDrawable(shape, inset, inset, inset, inset)
+        return RippleDrawable(rippleColor, content, content.constantState?.newDrawable()?.mutate())
     }
 
     private fun setupBottomRowKeyboard(editorInfo: EditorInfo, listener: KeyboardActionListener) {
@@ -151,7 +179,7 @@ class ClipboardHistoryView @JvmOverloads constructor(
     ) {
         clipboardHistoryManager = historyManager
         initialize()
-        setupToolbarKeys()
+        setupHeader()
         historyManager.prepareClipboardHistory()
         historyManager.setHistoryChangeListener(this)
         clipboardAdapter.clipboardHistoryManager = historyManager
@@ -185,9 +213,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
             keyboardAttr.recycle()
             setPadding(leftPadding, paddingTop, rightPadding, paddingBottom)
         }
-
-        // absurd workaround so Android sets the correct color from stateList (depending on "activated")
-        toolbarKeys.forEach { it.isEnabled = false; it.isEnabled = true }
     }
 
     fun stopClipboardHistory() {
@@ -198,33 +223,15 @@ class ClipboardHistoryView @JvmOverloads constructor(
     }
 
     override fun onClick(view: View) {
-        val tag = view.tag
-        if (tag is ToolbarKey) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_PRESS)
-            val code = getCodeForToolbarKey(tag)
-            if (code != KeyCode.UNSPECIFIED) {
-                keyboardActionListener.onCodeInput(code, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
-                return
-            }
+        AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_PRESS)
+        val code = when (view.id) {
+            R.id.clipboard_back_button -> KeyCode.ALPHA
+            R.id.clipboard_clear_button -> KeyCode.CLIPBOARD_CLEAR_HISTORY
+            else -> KeyCode.UNSPECIFIED
         }
-    }
-
-    override fun onLongClick(view: View): Boolean {
-        val tag = view.tag
-        if (tag is ToolbarKey) {
-            AudioAndHapticFeedbackManager.getInstance().performHapticAndAudioFeedback(KeyCode.NOT_SPECIFIED, this, HapticEvent.KEY_LONG_PRESS)
-            val longClickCode = getCodeForToolbarKeyLongClick(tag)
-            if (longClickCode != KeyCode.UNSPECIFIED) {
-                keyboardActionListener.onCodeInput(
-                    longClickCode,
-                    Constants.NOT_A_COORDINATE,
-                    Constants.NOT_A_COORDINATE,
-                    false
-                )
-            }
-            return true
+        if (code != KeyCode.UNSPECIFIED) {
+            keyboardActionListener.onCodeInput(code, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE, false)
         }
-        return false
     }
 
     override fun onKeyDown(clipId: Long) {
@@ -257,8 +264,6 @@ class ClipboardHistoryView @JvmOverloads constructor(
     }
 
     override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {
-        setToolbarButtonsActivatedStateOnPrefChange(KeyboardSwitcher.getInstance().clipboardStrip, key)
-
         // The setting can only be changed from a settings screen, but adding it to this listener seems necessary: https://github.com/HeliBorg/HeliBoard/pull/1903#issuecomment-3478424606
         if (::clipboardHistoryManager.isInitialized && key == Settings.PREF_CLIPBOARD_HISTORY_PINNED_FIRST) {
             // Ensure settings are reloaded first

--- a/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
+++ b/app/src/main/java/helium314/keyboard/latin/AppUpgrade.kt
@@ -425,7 +425,7 @@ private object AppUpgrade {
         }
         if (oldVersion <= 2305) {
             (prefs.all.keys.filter { it.startsWith(Settings.PREF_POPUP_KEYS_ORDER) || it.startsWith(Settings.PREF_POPUP_KEYS_HINT_ORDER) } +
-                listOf(Settings.PREF_TOOLBAR_KEYS, Settings.PREF_PINNED_TOOLBAR_KEYS, Settings.PREF_CLIPBOARD_TOOLBAR_KEYS)).forEach {
+                listOf(Settings.PREF_TOOLBAR_KEYS, Settings.PREF_PINNED_TOOLBAR_KEYS)).forEach {
                 if (!prefs.contains(it)) return@forEach
                 val newValue = prefs.getString(it, "")!!.replace(",", Separators.KV).replace(";", Separators.ENTRY)
                 prefs.edit { putString(it, newValue) }

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -113,6 +113,7 @@ class ClipboardHistoryManager(
                 onScreenshotMediaChanged()
             }
 
+            @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
             override fun onChange(selfChange: Boolean, uris: Collection<Uri>, flags: Int) {
                 super.onChange(selfChange, uris, flags)
                 onScreenshotMediaChanged()

--- a/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
+++ b/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
@@ -312,7 +312,9 @@ object FrostedGlassHelper {
         Log.d(TAG, "Samsung SDK ${Build.VERSION.SDK_INT}: using SemBlurInfo path; enable=$enable")
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-        window.setBackgroundBlurRadius(0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            window.setBackgroundBlurRadius(0)
+        }
         window.setBackgroundDrawable(roundedWindowBackground(context, Color.TRANSPARENT))
         val decorView = window.decorView
         decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
@@ -442,8 +444,10 @@ object FrostedGlassHelper {
         decorView.clipToOutline = true
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-        window.setBackgroundBlurRadius(targetRadius)
-        Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            window.setBackgroundBlurRadius(targetRadius)
+            Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+        }
 
         defaultBlurStates[window] = desiredState
         return true
@@ -518,6 +522,7 @@ object FrostedGlassHelper {
     }
 
     private fun isSystemBlurAvailable(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
         if (isBatterySaverMode(context)) return false
         return try {
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager

--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -13,7 +13,6 @@ import helium314.keyboard.latin.common.Constants.Subtype.ExtraValue
 import helium314.keyboard.latin.utils.LayoutType
 import helium314.keyboard.latin.utils.POPUP_KEYS_LABEL_DEFAULT
 import helium314.keyboard.latin.utils.POPUP_KEYS_ORDER_DEFAULT
-import helium314.keyboard.latin.utils.defaultClipboardToolbarPref
 import helium314.keyboard.latin.utils.defaultPersistentToolbarKey
 import helium314.keyboard.latin.utils.defaultPinnedToolbarPref
 import helium314.keyboard.latin.utils.defaultToolbarPref
@@ -169,7 +168,6 @@ object Defaults {
     val PREF_TOOLBAR_KEYS = defaultToolbarPref
     const val PREF_AUTO_SHOW_TOOLBAR = false
     const val PREF_AUTO_HIDE_TOOLBAR = false
-    val PREF_CLIPBOARD_TOOLBAR_KEYS = defaultClipboardToolbarPref
     const val PREF_ABC_AFTER_EMOJI = false
     const val PREF_ABC_AFTER_CLIP = false
     const val PREF_ABC_AFTER_SYMBOL_SPACE = true

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -209,7 +209,6 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_TOOLBAR_KEYS = "toolbar_keys";
     public static final String PREF_AUTO_SHOW_TOOLBAR = "auto_show_toolbar";
     public static final String PREF_AUTO_HIDE_TOOLBAR = "auto_hide_toolbar";
-    public static final String PREF_CLIPBOARD_TOOLBAR_KEYS = "clipboard_toolbar_keys";
     public static final String PREF_ABC_AFTER_EMOJI = "abc_after_emoji";
     public static final String PREF_ABC_AFTER_CLIP = "abc_after_clip";
     public static final String PREF_ABC_AFTER_SYMBOL_SPACE = "abc_after_symbol_space";

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -74,6 +74,7 @@ import helium314.keyboard.latin.utils.pinToolbarKeyAt
 import helium314.keyboard.latin.utils.prefs
 import helium314.keyboard.latin.utils.removeFirst
 import helium314.keyboard.latin.utils.setToolbarButtonsActivatedStateOnPrefChange
+import helium314.keyboard.latin.utils.startDragAndDropCompat
 import helium314.keyboard.latin.utils.updateToolbarButtonActivatedState
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
@@ -609,8 +610,16 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
         val toolbarMode = Settings.getValues().mToolbarMode
         val allowPinnedKeys = toolbarMode == ToolbarMode.EXPANDABLE || toolbarMode == ToolbarMode.TOOLBAR_KEYS
         val allowSuggestions = toolbarMode == ToolbarMode.EXPANDABLE || toolbarMode == ToolbarMode.SUGGESTION_STRIP
+        val isFieldEmpty = isTextFieldEmpty()
+        // Keep empty-editor ownership stable when beginning-of-sentence predictions arrive asynchronously.
+        val showPinnedKeysForEmptyField = showSuggestions &&
+                allowPinnedKeys &&
+                !isExternalSuggestionVisible &&
+                isFieldEmpty &&
+                pinnedKeys.childCount > 0
         val showSuggestionContent = showSuggestions && allowSuggestions &&
-                (isExternalSuggestionVisible || shouldShowSuggestionContent())
+                !showPinnedKeysForEmptyField &&
+                (isExternalSuggestionVisible || !isFieldEmpty || shouldShowSuggestionContent())
         val showChips = showSuggestionContent && !isExternalSuggestionVisible && shouldUseChipSuggestions()
         suggestionsStrip.isVisible = showSuggestionContent && !showChips
         suggestionsChipScroll.isVisible = showChips
@@ -845,7 +854,11 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
     private fun startPinnedToolbarDrag(view: View, key: ToolbarKey) {
         val clipData = ClipData.newPlainText(TOOLBAR_DRAG_CLIP_LABEL, key.name)
         view.visibility = INVISIBLE
-        view.startDragAndDrop(clipData, DragShadowBuilder(view), ToolbarDragState(key, ToolbarDragSource.PINNED_ROW, view), 0)
+        view.startDragAndDropCompat(
+            clipData,
+            DragShadowBuilder(view),
+            ToolbarDragState(key, ToolbarDragSource.PINNED_ROW, view),
+        )
     }
 
     private fun applyToolbarPillBackground(view: ImageButton, colors: Colors) {
@@ -924,6 +937,23 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
         applyAlphabetIconTint(accessPointTriggerBtn, colors)
         applySuggestionStripButtonIconSizing(accessPointTriggerBtn)
         updateSuggestionContainersVisibility(true)
+    }
+
+    private fun isTextFieldEmpty(): Boolean {
+        val ime = getLatinIME() ?: return true
+        val connection = ime.currentInputConnection ?: return true
+        val before = connection.getTextBeforeCursor(1, 0)
+        val after = connection.getTextAfterCursor(1, 0)
+        return (before == null || before.isEmpty()) && (after == null || after.isEmpty())
+    }
+
+    private fun getLatinIME(): helium314.keyboard.latin.LatinIME? {
+        var ctx = context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is helium314.keyboard.latin.LatinIME) return ctx
+            ctx = ctx.baseContext
+        }
+        return ctx as? helium314.keyboard.latin.LatinIME
     }
 
     companion object {

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -272,7 +272,11 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
         suggestionsChipScroll.isVisible = false
         pinnedKeys.isVisible = pinnedKeys.childCount > 0
         // Swap access point icon to back arrow while menu is open
-        setAccessPointIcon(isMenuOpen = true)
+        setAccessPointMenuOpen(true)
+    }
+
+    fun setAccessPointMenuOpen(isOpen: Boolean) {
+        setAccessPointIcon(isMenuOpen = isOpen)
     }
 
     fun setSuggestions(suggestions: SuggestedWords, isRtlLanguage: Boolean) {

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -166,18 +166,10 @@ val defaultPinnedToolbarPref = entries.filterNot { it == CLOSE_HISTORY }.joinToS
 
 val defaultPersistentToolbarKey = VOICE.name
 
-val defaultClipboardToolbarPref by lazy {
-    val default = listOf(CLEAR_CLIPBOARD, UP, DOWN, LEFT, RIGHT, UNDO, CUT, COPY, PASTE, SELECT_WORD, CLOSE_HISTORY)
-    val others = entries.filterNot { it in default }
-    default.joinToString(Separators.ENTRY) { it.name + Separators.KV + true } + Separators.ENTRY +
-            others.joinToString(Separators.ENTRY) { it.name + Separators.KV + false }
-}
-
 /** add missing keys, typically because a new key has been added */
 fun upgradeToolbarPrefs(prefs: SharedPreferences) {
     upgradeToolbarPref(prefs, Settings.PREF_TOOLBAR_KEYS, defaultToolbarPref)
     upgradeToolbarPref(prefs, Settings.PREF_PINNED_TOOLBAR_KEYS, defaultPinnedToolbarPref)
-    upgradeToolbarPref(prefs, Settings.PREF_CLIPBOARD_TOOLBAR_KEYS, defaultClipboardToolbarPref)
 }
 
 private fun upgradeToolbarPref(prefs: SharedPreferences, pref: String, default: String) {
@@ -210,8 +202,6 @@ fun getPinnedToolbarKeys(prefs: SharedPreferences, excludedKey: ToolbarKey? = nu
     getEnabledToolbarKeys(prefs, Settings.PREF_PINNED_TOOLBAR_KEYS, defaultPinnedToolbarPref)
         .filterNot { it == excludedKey }
         .take(MAX_PINNED_TOOLBAR_KEYS)
-
-fun getEnabledClipboardToolbarKeys(prefs: SharedPreferences) = getEnabledToolbarKeys(prefs, Settings.PREF_CLIPBOARD_TOOLBAR_KEYS, defaultClipboardToolbarPref)
 
 fun getToolbarKeyFromDragData(localState: Any?, clipData: ClipData?): ToolbarKey? {
     (localState as? ToolbarDragState)?.let { return it.key }

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -4,7 +4,9 @@ package helium314.keyboard.latin.utils
 import android.content.Context
 import android.content.ClipData
 import android.content.SharedPreferences
+import android.os.Build
 import android.view.View
+import android.view.View.DragShadowBuilder
 import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ImageView
@@ -36,6 +38,18 @@ data class ToolbarDragState(
     val source: ToolbarDragSource,
     val sourceView: View? = null,
 )
+
+@Suppress("DEPRECATION")
+fun View.startDragAndDropCompat(
+    clipData: ClipData,
+    shadowBuilder: DragShadowBuilder,
+    localState: Any?,
+    flags: Int = 0,
+): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    startDragAndDrop(clipData, shadowBuilder, localState, flags)
+} else {
+    startDrag(clipData, shadowBuilder, localState, flags)
+}
 
 fun createToolbarKey(context: Context, key: ToolbarKey): ImageButton {
     val button = ImageButton(context, null, R.attr.suggestionWordStyle)

--- a/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
@@ -44,7 +44,7 @@ fun ToolbarScreen(
     if ((b?.value ?: 0) < 0)
         Log.v("irrelevant", "stupid way to trigger recomposition on preference change")
     val toolbarMode = Settings.readToolbarMode(prefs)
-    val clipboardToolbarVisible = toolbarMode != ToolbarMode.HIDDEN
+    val customToolbarCodesVisible = toolbarMode != ToolbarMode.HIDDEN
         || !prefs.getBoolean(Settings.PREF_TOOLBAR_HIDING_GLOBAL, Defaults.PREF_TOOLBAR_HIDING_GLOBAL)
     val items = listOf(
         Settings.PREF_TOOLBAR_MODE,
@@ -56,8 +56,7 @@ fun ToolbarScreen(
             else -> null
         },
         if (toolbarMode != ToolbarMode.HIDDEN) Settings.PREF_PERSISTENT_TOOLBAR_KEY else null,
-        if (clipboardToolbarVisible) Settings.PREF_CLIPBOARD_TOOLBAR_KEYS else null,
-        if (clipboardToolbarVisible) Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES else null,
+        if (customToolbarCodesVisible) Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES else null,
         if (toolbarMode != ToolbarMode.HIDDEN) Settings.PREF_VARIABLE_TOOLBAR_DIRECTION else null,
     )
     SearchSettingsScreen(
@@ -103,9 +102,6 @@ fun createToolbarSettings(context: Context) = listOf(
                 .map { it.name.lowercase().getStringResourceOrName("", ctx) to it.name },
             Defaults.PREF_PERSISTENT_TOOLBAR_KEY
         )
-    },
-    Setting(context, Settings.PREF_CLIPBOARD_TOOLBAR_KEYS, R.string.clipboard_toolbar_keys) {
-        ReorderSwitchPreference(it, Defaults.PREF_CLIPBOARD_TOOLBAR_KEYS)
     },
     Setting(context, Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES, R.string.customize_toolbar_key_codes) {
         var showDialog by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/res/layout/clipboard_history_view.xml
+++ b/app/src/main/res/layout/clipboard_history_view.xml
@@ -14,6 +14,41 @@
     android:paddingTop="6dp"
     style="?attr/clipboardHistoryViewStyle">
 
+    <LinearLayout
+        android:id="@+id/clipboard_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp">
+
+        <ImageButton
+            android:id="@+id/clipboard_back_button"
+            android:layout_width="38dp"
+            android:layout_height="38dp"
+            android:contentDescription="@string/abc_action_bar_up_description"
+            android:src="@drawable/ic_arrow_back" />
+
+        <TextView
+            android:id="@+id/clipboard_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="8dp"
+            android:text="@string/clipboard"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/clipboard_clear_button"
+            android:layout_width="38dp"
+            android:layout_height="38dp"
+            android:contentDescription="@string/clear_clipboard" />
+
+    </LinearLayout>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -302,7 +302,6 @@
     <string name="center_suggestion_text_to_enter">استخدم دائمًا الاقتراح الأوسط</string>
     <string name="center_suggestion_text_to_enter_summary">عند الضغط على مسافة أو علامات الترقيم، سيتم إدخال الاقتراح الأوسط</string>
     <string name="close_history" tools:keep="@string/close_history">أغلِق تاريخ الحافظة</string>
-    <string name="clipboard_toolbar_keys">حدد مفاتيح شريط أدوات الحافظة</string>
     <string name="subtype_generic_extended">%s (ممتدة)</string>
     <string name="subtype_mns">مانسي</string>
     <string name="more_colors">أظهِر المزيد من الالوان</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -297,7 +297,6 @@
     <string name="language_switch_key_behavior">Паводзіны клавішы змены мовы</string>
     <string name="center_suggestion_text_to_enter">Заўсёды выкарыстоўваць сярэднюю прапанову</string>
     <string name="gesture_fast_typing_cooldown">Час аднаўлення хуткага друку</string>
-    <string name="clipboard_toolbar_keys">Выбраць клавішы панэлі інструментаў буфера абмену</string>
     <string name="all_colors_warning">Гэтая настройка паказвае ўсе колеры, якія выкарыстоўваюцца ўнутры праграмы. Спіс колераў можа мяняцца. Колер па змаўчанні з\'яўляецца выпадковым, і імёны не будуць перакладзены.</string>
     <string name="auto_show_toolbar_summary">Паказваць панэль інструментаў пры ўводзе ці пры выбары тэксту</string>
     <string name="auto_hide_toolbar">Хаваць панэль інструментаў аўтаматычна</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -186,7 +186,6 @@
     <string name="full_left" tools:keep="@string/full_left">Напълно вляво</string>
     <string name="full_right" tools:keep="@string/full_right">Напълно вдясно</string>
     <string name="close_history" tools:keep="@string/close_history">Затваряне на хронологията на клипборда</string>
-    <string name="clipboard_toolbar_keys">Избиране на клавиши от лентата с инструменти за клипборд</string>
     <string name="quick_pin_toolbar_keys">Закачи клавиш от лентата с инструменти при дълго натискане</string>
     <string name="layout_numpad" tools:keep="@string/layout_numpad">Цифрова клавиатура</string>
     <string name="prefs_space_bar_text">Персонализиран текст в лентата за интервал</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -302,7 +302,6 @@
     <string name="auto_hide_toolbar_summary">পরামর্শ উপলব্ধ হলে টুলবার আড়াল হবে</string>
     <string name="auto_show_toolbar">টুলবার স্বয়ংক্রিয়ভাবে প্রদর্শন</string>
     <string name="close_history" tools:keep="@string/close_history">ক্লিপবোর্ড ইতিহাস বন্ধকরণ</string>
-    <string name="clipboard_toolbar_keys">ক্লিপবোর্ড টুলবার বোতাম নির্বাচন</string>
     <string name="subtype_generic_extended">%s (বর্ধিত)</string>
     <string name="emoji" tools:keep="@string/emoji">ইমোজি</string>
     <string name="settings_screen_toolbar">টুলবার</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -189,7 +189,6 @@
     <string name="replace_dictionary_message">Realment substituir el diccionari afegit per l\'usuari «%1$s»?\n\nDiccionari actual:\n%2$s\n\nNou diccionari:\n%3$s</string>
     <string name="replace_dictionary">Substitueix diccionari</string>
     <string name="remove_dictionary_message">Eliminar realment el diccionari afegit per l\'usuari «%s»?</string>
-    <string name="clipboard_toolbar_keys">Selecciona les tecles de la barra d\'eines del porta-retalls</string>
     <string name="close_history" tools:keep="@string/close_history">Tanca l\'historial del porta-retalls</string>
     <string name="layout_symbols_arabic" tools:keep="@string/layout_symbols_arabic">Símbols (Àrab)</string>
     <string name="layout_symbols" tools:keep="@string/layout_symbols">Símbols</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -193,7 +193,6 @@
     <string name="action_none">Žádné</string>
     <string name="subtype_xdq">Kaitag</string>
     <string name="close_history" tools:keep="@string/close_history">Zavřít historii schránky</string>
-    <string name="clipboard_toolbar_keys">Výběr kláves panelu nástrojů schránky</string>
     <string name="prefs_bottom_padding_scale">Měřítko dolního odsazení</string>
     <string name="message_add_custom_layout">Vybrat soubor v kompatibilním formátu. Informace o formátech jsou k dispozici %s.</string>
     <string name="layout_symbols" tools:keep="@string/layout_symbols">Symboly</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -293,7 +293,6 @@
     <string name="center_suggestion_text_to_enter_summary">Bei Eingabe eines Leerzeichens oder eines Punktes wird der mittlere Vorschlag gewählt</string>
     <string name="close_history" tools:keep="@string/close_history">Zwischenablage-Verlauf schließen</string>
     <string name="center_suggestion_text_to_enter">Immer mittleren Vorschlag verwenden</string>
-    <string name="clipboard_toolbar_keys">Tasten der Symbolleiste für die Zwischenablage auswählen</string>
     <string name="subtype_generic_extended">%s (Erweitert)</string>
     <string name="pinned_toolbar_keys">Angeheftete Tasten der Symbolleiste auswählen</string>
     <string name="quick_pin_toolbar_keys_summary">Dadurch werden andere Langdruck-Aktionen für Tasten der Symbolleiste, die nicht angeheftet sind, deaktiviert</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -302,7 +302,6 @@
     <string name="center_suggestion_text_to_enter">Utilizar siempre la sugerencia del centro</string>
     <string name="center_suggestion_text_to_enter_summary">Al presionar espacio o puntuación, se ingresará la sugerencia central</string>
     <string name="close_history" tools:keep="@string/close_history">Cerrar el historial del portapapeles</string>
-    <string name="clipboard_toolbar_keys">Seleccionar teclas de la barra de herramientas del portapapeles</string>
     <string name="subtype_generic_extended">%s (Extendido)</string>
     <string name="subtype_mns">Mansi</string>
     <string name="more_colors">Mostrar más colores</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -266,7 +266,6 @@
     <string name="var_toolbar_direction">Dirección variable de la barra de herramientas</string>
     <string name="subtype_xdq">Kaitag</string>
     <string name="close_history" tools:keep="@string/close_history">Cerrar historial del portapapeles</string>
-    <string name="clipboard_toolbar_keys">Seleccionar teclas de la barra de herramientas del portapapeles</string>
     <string name="show_popup_hints">Mostrar símbolos funcionales</string>
     <string name="show_popup_hints_summary">Muestra símbolos si al mantener pulsada una tecla se activan funciones adicionales</string>
     <string name="var_toolbar_direction_summary">Invertir dirección cuando un subtipo de teclado Derecha-a-Izquierda está seleccionado</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -214,7 +214,6 @@
     <string name="button_load_custom">Laadi fail</string>
     <string name="subtype_mns">Mansi</string>
     <string name="prefs_space_bar_text">Sinu tekst tühikuklahvil</string>
-    <string name="clipboard_toolbar_keys">Vali lõikelaua nupud tööriistariba jaoks</string>
     <string name="subtype_generic_extended">%s (laiendatud)</string>
     <string name="load">Laadi</string>
     <string name="button_title_add_custom_layout">Lisa kohandatud paigutus</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -304,7 +304,6 @@
     <string name="center_suggestion_text_to_enter">Erabili beti erdiko iradokizuna</string>
     <string name="center_suggestion_text_to_enter_summary">Zuriunea edo puntuazioa sakatzean, erdiko iradokizuna sartuko da</string>
     <string name="close_history" tools:keep="@string/close_history">Itxi arbelaren historia</string>
-    <string name="clipboard_toolbar_keys">Hautatu arbeleko tresna-barrako teklak</string>
     <string name="more_colors">Erakutsi kolore gehiago</string>
     <string name="all_colors_warning">Ezarpen honek barnean erabiltzen diren kolore guztiak agerian uzten ditu. Koloreen zerrenda edozein unetan alda daiteke. Kolore lehenetsia aleatorioa da, eta izenak ez dira itzuliko.</string>
     <string name="layout_functional_keys" tools:keep="@string/layout_functional_keys">Funtzio-teklak</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -181,7 +181,6 @@
     <string name="day_night_mode_summary">Ulkoasu seuraa järjestelmän asetuksia</string>
     <string name="select_color_background">Näppäimistön tausta</string>
     <string name="emoji" tools:keep="@string/emoji">Emoji</string>
-    <string name="clipboard_toolbar_keys">Valitse leikepöydän työkalupalkin näppäimet</string>
     <string name="setup_step3_action">Muokkaa näppäimistöä</string>
     <string name="text_tap_languages">Napauta kieltä avataksesi sen asetukset</string>
     <string name="save_log">Tallenna loki</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -298,7 +298,6 @@ Nouveau dictionnaire:
     <string name="center_suggestion_text_to_enter">Toujours utiliser la suggestion du milieu</string>
     <string name="center_suggestion_text_to_enter_summary">En appuyant sur espace ou sur un signe de ponctuation, la suggestion du milieu sera saisie</string>
     <string name="close_history" tools:keep="@string/close_history">Fermer le presse-papiers</string>
-    <string name="clipboard_toolbar_keys">Sélectionner les touches de la barre d\'outils du presse-papiers</string>
     <string name="subtype_generic_extended">%s (Étendu)</string>
     <string name="subtype_mns">Mansi</string>
     <string name="more_colors">Afficher plus de couleurs</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -301,7 +301,6 @@
     <string name="prefs_long_press_symbol_for_numpad">Tecla con pulsación longa para teclado numérico</string>
     <string name="center_suggestion_text_to_enter">Usar sempre a suxestión do medio</string>
     <string name="center_suggestion_text_to_enter_summary">Ao premer no espazo ou puntuación, escríbese a suxestión do medio</string>
-    <string name="clipboard_toolbar_keys">Escoller teclas da barra de ferramentas do portapapeis</string>
     <string name="close_history" tools:keep="@string/close_history">Pechar historial do portapapeis</string>
     <string name="subtype_generic_extended">%s (Extendido)</string>
     <string name="subtype_mns">Mansi</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -238,7 +238,6 @@
     <string name="down" tools:keep="@string/down">Dolje</string>
     <string name="close_history" tools:keep="@string/close_history">Zatvori povijest međuspremnika</string>
     <string name="emoji" tools:keep="@string/emoji">Emoji</string>
-    <string name="clipboard_toolbar_keys">Odaberi tipke alatne trake međuspremnika</string>
     <string name="pinned_toolbar_keys">Odaberi prikvačene tipke alatne trake</string>
     <string name="quick_pin_toolbar_keys">Prikvači tipke alatne trake pomoću dugog pritiska</string>
     <string name="quick_pin_toolbar_keys_summary">Ovo će onemogućiti druge radnje za dugi pritisak tipki alatne trake koje nisu prikvačene</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -371,7 +371,6 @@
     <string name="word_left" tools:keep="@string/word_left">Balra lévő szó</string>
     <string name="word_right" tools:keep="@string/word_right">Jobbra lévő szó</string>
     <string name="close_history" tools:keep="@string/close_history">Vágólapelőzmények bezárása</string>
-    <string name="clipboard_toolbar_keys">Vágólapeszköztár billentyűinek kiválasztása</string>
     <string name="pinned_toolbar_keys">Kitűzött eszköztárbillentyűk kiválasztása</string>
     <string name="prefs_font_scale">Billentyűzet betűmérete</string>
     <string name="prefs_emoji_skin_tone_neutral">Semleges</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -324,7 +324,6 @@
     <string name="vibrate_in_dnd_mode">Bergetar dalam mode jangan ganggu</string>
     <string name="page_end" tools:keep="@string/page_end">Akhir halaman</string>
     <string name="word_left" tools:keep="@string/word_left">Kata tersisa</string>
-    <string name="clipboard_toolbar_keys">Pilih tombol bilah alat papan klip</string>
     <string name="quick_pin_toolbar_keys">Sematkan tombol bilah alat saat ditekan lama</string>
     <string name="quick_pin_toolbar_keys_summary">Ini akan menonaktifkan tindakan tekan lama lainnya untuk tombol bilah alat yang tidak disematkan</string>
     <string name="prefs_long_press_symbol_for_numpad">Tekan lama tombol simbol untuk papan nomor</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -301,7 +301,6 @@
     <string name="custom_font">Velja sérsniðið letur úr skrá</string>
     <string name="hint_source">Veldu uppruna ábendinga</string>
     <string name="toolbar_keys">Veldu lykla á verkfærastiku</string>
-    <string name="clipboard_toolbar_keys">Veldu klippispjaldslykla á verkfærastiku</string>
     <string name="customize_currencies_detail">Stilltu aðal- og allt að 6 viðbótar gjaldmiðlatákn, aðskilin með bilum</string>
     <string name="disable_personalized_dicts_message">Aðvörun: Sé þessi stilling gerð óvirk verða öll lærð gögn hreinsuð</string>
     <string name="dictionary_file_error">Villa: Valin skrá er ekki gild orðasafnsskrá</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -312,7 +312,6 @@
     <string name="settings_screen_toolbar">Barra degli strumenti</string>
     <string name="center_suggestion_text_to_enter">Usa sempre la parola suggerita al centro</string>
     <string name="close_history" tools:keep="@string/close_history">Chiudi la cronologia appunti</string>
-    <string name="clipboard_toolbar_keys">Scegli i tasti mostrati insieme alla cronologia appunti (nella barra superiore)</string>
     <string name="language_switch_key_behavior">Comportamento del tasto \'Cambia lingua\'</string>
     <string name="center_suggestion_text_to_enter_summary">All\'aggiunta di uno spazio o di un segno di punteggiatura, il suggerimento centrale è inserito automaticamente</string>
     <string name="toast_msg_clipboard_copy">Testo copiato</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -219,7 +219,6 @@
     <string name="dictionary_settings_category">מילונים</string>
     <string name="theme_style">סגנון</string>
     <string name="close_history" tools:keep="@string/close_history">סגירת היסטוריית הלוח</string>
-    <string name="clipboard_toolbar_keys">בחירת כפתורי סרגל הכלים של הלוח</string>
     <string name="edit_layout">לחיצה לעריכת פריסת בסיס</string>
     <string name="theme_name_chocolate" tools:keep="@string/theme_name_chocolate">שוקולד</string>
     <string name="layout_symbols" tools:keep="@string/layout_symbols">סימנים</string>

--- a/app/src/main/res/values-kab/strings.xml
+++ b/app/src/main/res/values-kab/strings.xml
@@ -152,7 +152,6 @@
     <string name="toolbar_mode_hidden" tools:keep="@string/toolbar_mode_hidden">Tettwaffer</string>
     <string name="clipboard" tools:keep="@string/clipboard">Tacfawit</string>
     <string name="clear_clipboard" tools:keep="@string/clear_clipboard">Sfeḍ tacfawit</string>
-    <string name="clipboard_toolbar_keys">Fren tiqeffalin n tfeggagt n tifecka n tecfawit</string>
     <string name="subtype_generic_student">%s (Anelmad)</string>
     <string name="layout_symbols_arabic" tools:keep="@string/layout_symbols_arabic">Izamulen (Taɛrabt)</string>
     <string name="setup_step1_title">Sermed %s</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -240,7 +240,6 @@
     <string name="page_down" tools:keep="@string/page_down">Puslapis žemyn</string>
     <string name="close_history" tools:keep="@string/close_history">Užverti iškarpinės istoriją</string>
     <string name="emoji" tools:keep="@string/emoji">Jaustukai</string>
-    <string name="clipboard_toolbar_keys">Pasirinkti iškarpinės įrankių juostos mygtukus</string>
     <string name="pinned_toolbar_keys">Pasirinkti prisegtus įrankių juostos mygtukus</string>
     <string name="quick_pin_toolbar_keys">Ilgai paspaudus prisegti įrankių juostos mygtuką</string>
     <string name="prefs_long_press_keyboard_to_change_lang">Pakeisti įvesties režimą su tarpo klavišu</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -192,7 +192,6 @@
     <string name="theme_name_user" tools:keep="@string/theme_name_user">Aangepast</string>
     <string name="show_horizontal_space_swipe">Horizontaal veeggebaar over spatiebalk</string>
     <string name="close_history" tools:keep="@string/close_history">Klembordgeschiedenis sluiten</string>
-    <string name="clipboard_toolbar_keys">Klembord-werkbalktoetsen kiezen</string>
     <string name="prefs_long_press_symbol_for_numpad">Druk lang op de toets symbolen voor het numpad</string>
     <string name="button_load_custom">Bestand laden</string>
     <string name="file_read_error">Kan bestand niet lezen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -337,7 +337,6 @@
     <string name="center_suggestion_text_to_enter">Zawsze używaj środkowej sugestii</string>
     <string name="center_suggestion_text_to_enter_summary">Po naciśnięciu spacji lub znaku interpunkcyjnego zostanie wpisana środkowa sugestia</string>
     <string name="close_history" tools:keep="@string/close_history">Zamknij schowek</string>
-    <string name="clipboard_toolbar_keys">Wybierz klawisze paska narzędzi w schowku</string>
     <string name="subtype_generic_extended">%s (rozszerzony)</string>
     <string name="subtype_mns">mansyjski</string>
     <string name="more_colors">Pokaż więcej kolorów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -301,7 +301,6 @@
     <string name="center_suggestion_text_to_enter">Sempre usar a sugestão do meio</string>
     <string name="center_suggestion_text_to_enter_summary">Ao pressionar espaço ou pontuação, a sugestão do meio será inserida</string>
     <string name="close_history" tools:keep="@string/close_history">Fechar histórico da área de transferência</string>
-    <string name="clipboard_toolbar_keys">Selecionar teclas da barra de ferramentas de área de transferência</string>
     <string name="subtype_generic_extended">%s (Extendido)</string>
     <string name="all_colors_warning">Essa configuração expõe todas as cores que são usadas internamente. A lista de cores pode mudar a qualquer momento. A cor padrão é derivada das cores normais, e os nomes não são traduzidos.</string>
     <string name="pinned_toolbar_keys">Selecionar teclas fixadas da barra de ferramentas</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -299,7 +299,6 @@
     <string name="show_tld_popup_keys_summary">Substituir popups de ponto final por domínios de topo ao digitar URLs e endereços de e-mail</string>
     <string name="split" tools:keep="@string/split">Teclado dividido</string>
     <string name="page_down" tools:keep="@string/page_down">Página para baixo</string>
-    <string name="clipboard_toolbar_keys">Selecionar teclas da barra de ferramentas de área de transferência</string>
     <string name="quick_pin_toolbar_keys_summary">Desativa outras ações de toque longo para teclas da barra de ferramentas desafixadas</string>
     <string name="show_popup_hints">Mostrar dicas funcionais</string>
     <string name="show_popup_hints_summary">Mostrar dicas se um toque longo numa tecla ativa funcionalidade adicional</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -305,7 +305,6 @@
     <string name="no_dictionary_dont_show_again_button">Não mostrar novamente</string>
     <string name="available_dictionary_experimental">%s (experimental)</string>
     <string name="replace_dictionary_message">Substituir o dicionário \"%1$s\" adicionado pelo utilizador?\n\nDicionário atual:\n%2$s\n\nNovo dicionário:\n%3$s</string>
-    <string name="clipboard_toolbar_keys">Selecionar teclas da barra de ferramentas da área de transferência</string>
     <string name="remove_redundant_popups">Remover pop-ups redundantes</string>
     <string name="pinned_toolbar_keys">Selecionar teclas afixadas da barra de ferramentas</string>
     <string name="quick_pin_toolbar_keys">Fixar tecla da barra de ferramentas ao pressionar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -337,7 +337,6 @@
     <string name="page_down" tools:keep="@string/page_down">Pagină jos</string>
     <string name="quick_pin_toolbar_keys">Fixează tasta din bara de instrumente la apăsarea lungă</string>
     <string name="close_history" tools:keep="@string/close_history">Închide istoricul clipboardului</string>
-    <string name="clipboard_toolbar_keys">Selectează tastele barei de instrumente clipboard</string>
     <string name="switch_keyboard_after">Comutare la tastatura principală după…</string>
     <string name="after_emoji">Se selectează emoji în vizualizarea emoji</string>
     <string name="after_clip">Selectarea unei intrări din istoricul clipboardului</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -303,7 +303,6 @@
     <string name="center_suggestion_text_to_enter">Всегда использовать среднюю подсказку</string>
     <string name="center_suggestion_text_to_enter_summary">При нажатии пробела или знака препинания будет вставлена средняя подсказка</string>
     <string name="close_history" tools:keep="@string/close_history">Закрыть историю буфера обмена</string>
-    <string name="clipboard_toolbar_keys">Выбрать клавиши панели буфера обмена</string>
     <string name="subtype_generic_extended">%s (Расширенная)</string>
     <string name="auto_hide_toolbar_summary">Скрывать панель инструментов при появлении подсказок</string>
     <string name="settings_screen_toolbar">Панель инструментов</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -223,7 +223,6 @@
     <string name="popup_keys_layout" tools:keep="@string/popup_keys_layout">Layout</string>
     <string name="toolbar_keys">Välj verktygsfältstangenter</string>
     <string name="close_history" tools:keep="@string/close_history">Stäng urklippshistorik</string>
-    <string name="clipboard_toolbar_keys">Välj verktygsfältstangenter för urklipp</string>
     <string name="show_popup_hints_summary">Visa tips om långtryck på en tangent aktiverar ytterligare funktionalitet</string>
     <string name="show_popup_hints">Visa funktionalitetstips</string>
     <string name="clipboard" tools:keep="@string/clipboard">Urklipp</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -239,7 +239,6 @@
     <string name="page_down" tools:keep="@string/page_down">பக்கம் கீழே</string>
     <string name="close_history" tools:keep="@string/close_history">இடைநிலைப்பலகை வரலாற்றை மூடு</string>
     <string name="emoji" tools:keep="@string/emoji">ஈமோசி</string>
-    <string name="clipboard_toolbar_keys">இடைநிலைப்பலகை கருவிப்பட்டி விசைகளைத் தேர்ந்தெடுக்கவும்</string>
     <string name="pinned_toolbar_keys">பின் செய்யப்பட்ட கருவிப்பட்டி விசைகளைத் தேர்ந்தெடுக்கவும்</string>
     <string name="quick_pin_toolbar_keys">நீண்ட அழுத்தத்தில் கருவிப்பட்டி விசையை பின் செய்யவும்</string>
     <string name="quick_pin_toolbar_keys_summary">இது பின் செய்யப்படாத கருவிப்பட்டி விசைகளுக்கான பிற நீண்ட அழுத்த செயல்களை முடக்கும்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -231,7 +231,6 @@
     <string name="hidden_features_summary">Fark edilmeyebilecek özellikleri göster</string>
     <string name="hidden_features_text">cihaz korumalı depolama</string>
     <string name="close_history" tools:keep="@string/close_history">Pano geçmişini kapat</string>
-    <string name="clipboard_toolbar_keys">Pano araç çubuğu tuşlarını seç</string>
     <string name="show_popup_hints_summary">Bir tuşa uzun süre basmak ek işlevleri tetikliyorsa ipuçlarını göster</string>
     <string name="button_title_add_custom_layout">Özel düzen ekle</string>
     <string name="layout_symbols" tools:keep="@string/layout_symbols">Semboller</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -317,7 +317,6 @@
     <string name="word_right" tools:keep="@string/word_right">Слово правіше</string>
     <string name="page_up" tools:keep="@string/page_up">Сторінка вгору</string>
     <string name="page_down" tools:keep="@string/page_down">Сторінка вниз</string>
-    <string name="clipboard_toolbar_keys">Вибрати клавіші панелі інструментів буфера обміну</string>
     <string name="quick_pin_toolbar_keys">Закріплювати клавіші панелі інструментів при тривалому натисканні</string>
     <string name="quick_pin_toolbar_keys_summary">Це вимикає інші функції клавіш панелі інструментів при тривалому натисканні</string>
     <string name="page_start" tools:keep="@string/page_start">Початок сторінки</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -242,7 +242,6 @@
     <string name="word_right" tools:keep="@string/word_right">字词向右</string>
     <string name="page_up" tools:keep="@string/page_up">向上翻页</string>
     <string name="page_down" tools:keep="@string/page_down">向下翻页</string>
-    <string name="clipboard_toolbar_keys">选择剪贴板工具栏键</string>
     <string name="page_start" tools:keep="@string/page_start">页面开始</string>
     <string name="page_end" tools:keep="@string/page_end">页面结束</string>
     <string name="word_left" tools:keep="@string/word_left">字词向左</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,8 +403,6 @@
     <string name="redo" tools:keep="@string/redo">Redo</string>
     <string name="close_history" tools:keep="@string/close_history">Close clipboard history</string>
     <string name="emoji" tools:keep="@string/emoji">Emoji</string>
-    <!-- Title of the setting to set clipboard toolbar keys -->
-    <string name="clipboard_toolbar_keys">Select clipboard toolbar keys</string>
     <!-- Title of the setting to set pinned toolbar keys -->
     <string name="pinned_toolbar_keys">Select pinned toolbar buttons</string>
     <!-- Title of the setting to choose the fixed right-side toolbar button -->


### PR DESCRIPTION
## Summary
- Replace the customizable clipboard toolbar with a fixed clipboard header.
- Align the clipboard header with the AI writing tools panel design.
- Fix the quick-actions/access-point icon getting stuck as a back arrow after opening and closing clipboard from quick actions.
- Remove clipboard toolbar customization from settings.

## Details
The clipboard panel now has a simple built-in header with:
- a back button on the left
- a left-aligned “Clipboard” title
- a clear clipboard button on the right

This follows the same general structure as the AI writing tools toolbar and makes clipboard feel more consistent with the other full keyboard panels.

The old customizable clipboard toolbar has been removed. It exposed every toolbar key for customization, but out of those, realistically the clipboard panel only needs a way to go back/close and a way to clear clipboard history. Removing the extra options also simplifies the toolbar settings screen.

This also fixes a related state issue when navigating from quick actions to clipboard. Previously, opening quick actions, opening clipboard from there, and closing clipboard could leave the quick-actions button showing the back arrow even though it would open quick actions again. The access-point icon state is now reset when leaving the quick-actions menu.