### PR TITLE
fix(blur): round native background-blur corners and prevent flicker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId = "com.orion.kboard"
-        minSdk = 31
+        minSdk = 23
         targetSdk = 36
         versionCode = providers.of(GitCommitCountValueSource::class.java) {}.get()
         versionName = "2.5.6"

--- a/app/src/main/java/helium314/keyboard/keyboard/AccessPointMenuView.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/AccessPointMenuView.kt
@@ -39,6 +39,7 @@ import helium314.keyboard.latin.utils.getPinnedToolbarKeys
 import helium314.keyboard.latin.utils.getStringResourceOrName
 import helium314.keyboard.latin.utils.getToolbarKeyFromDragData
 import helium314.keyboard.latin.utils.removePinnedKey
+import helium314.keyboard.latin.utils.startDragAndDropCompat
 
 class AccessPointMenuView @JvmOverloads constructor(
     context: Context,
@@ -162,7 +163,11 @@ class AccessPointMenuView @JvmOverloads constructor(
                 val clipData = ClipData.newPlainText(TOOLBAR_DRAG_CLIP_LABEL, key.name)
                 val shadow = DragShadowBuilder(v)
                 v.visibility = View.INVISIBLE
-                v.startDragAndDrop(clipData, shadow, ToolbarDragState(key, ToolbarDragSource.ACCESS_POINT_MENU, v), 0)
+                v.startDragAndDropCompat(
+                    clipData,
+                    shadow,
+                    ToolbarDragState(key, ToolbarDragSource.ACCESS_POINT_MENU, v),
+                )
                 true
             }
 

--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -113,6 +113,7 @@ class ClipboardHistoryManager(
                 onScreenshotMediaChanged()
             }
 
+            @androidx.annotation.RequiresApi(Build.VERSION_CODES.R)
             override fun onChange(selfChange: Boolean, uris: Collection<Uri>, flags: Int) {
                 super.onChange(selfChange, uris, flags)
                 onScreenshotMediaChanged()

--- a/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
+++ b/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.util.Log
 import android.view.Gravity
 import android.view.View
-import android.view.ViewOutlineProvider
 import android.view.Window
 import android.view.WindowManager
 import helium314.keyboard.latin.common.ColorType
@@ -31,6 +30,7 @@ object FrostedGlassHelper {
 
     private const val TAG = "KBoardBlur"
     private const val SAMSUNG_EXTENSION_FLAG_BLUR = 0x10
+    private const val NATIVE_BLUR_HIDE_CLEANUP_DELAY_MS = 250L
     private val failedSamsungSemBlurModes = mutableSetOf<String>()
     private val windowsWithAppliedFrostedGlass: MutableSet<Window> =
         Collections.newSetFromMap(WeakHashMap<Window, Boolean>())
@@ -38,6 +38,8 @@ object FrostedGlassHelper {
         Collections.newSetFromMap(WeakHashMap<Window, Boolean>())
     private val defaultBlurStates: MutableMap<Window, DefaultBlurState> =
         Collections.synchronizedMap(WeakHashMap<Window, DefaultBlurState>())
+    private val nativeBlurStates: MutableMap<Window, NativeBlurState> =
+        Collections.synchronizedMap(WeakHashMap<Window, NativeBlurState>())
 
     private data class DefaultBlurState(
         val enabled: Boolean,
@@ -46,6 +48,17 @@ object FrostedGlassHelper {
         val backgroundBlurOnly: Boolean,
         val cornerRadiusPx: Float
     )
+
+    private class NativeBlurState {
+        var generation = 0
+        var ready = false
+        var decorView: View? = null
+        var inputView: View? = null
+        var cornerRadiusPx = -1f
+        var blurRadius = -1
+        var pendingCleanup: Runnable? = null
+        var pendingCleanupDecorView: View? = null
+    }
 
     // =========================================================================
     // LAZY STATICS: Pre-resolve reflection references ONCE and cache them forever
@@ -189,30 +202,52 @@ object FrostedGlassHelper {
         val window = service.window?.window ?: return
         if (suppressed) {
             windowsWithResizeOverlayBlurSuppressed.add(window)
-            configureFrostedGlass(service, inputView, false)
+            configureFrostedGlassInternal(service, inputView, false, allowDelayedNativeCleanup = false)
         } else {
             windowsWithResizeOverlayBlurSuppressed.remove(window)
-            configureFrostedGlass(service, inputView, restoreEnabled)
+            configureFrostedGlassInternal(service, inputView, restoreEnabled, allowDelayedNativeCleanup = true)
         }
     }
 
     @JvmStatic
     fun configureFrostedGlass(service: InputMethodService, inputView: View?, enable: Boolean) {
+        configureFrostedGlassInternal(service, inputView, enable, allowDelayedNativeCleanup = true)
+    }
+
+    private fun configureFrostedGlassInternal(
+        service: InputMethodService,
+        inputView: View?,
+        enable: Boolean,
+        allowDelayedNativeCleanup: Boolean
+    ) {
         val window = service.window?.window ?: return
+        val nativeState = nativeBlurState(window)
+        val generation = ++nativeState.generation
         val overrideMode = service.prefs().getString(Settings.PREF_BLUR_RENDER_OVERRIDE, "auto")
 
         if (enable && windowsWithResizeOverlayBlurSuppressed.contains(window)) {
-            configureFrostedGlass(service, inputView, false)
+            configureFrostedGlassInternal(service, inputView, false, allowDelayedNativeCleanup = false)
             return
         }
 
         if (!enable) {
-            val hadAppliedFrostedGlass = windowsWithAppliedFrostedGlass.remove(window)
-            if (!hadAppliedFrostedGlass && !hasNativeBlurFlag(window)) {
+            val hadAppliedFrostedGlass = windowsWithAppliedFrostedGlass.contains(window)
+            val hadDefaultBlurEnabled = defaultBlurStates[window]?.enabled == true
+            if (!hadAppliedFrostedGlass && !hadDefaultBlurEnabled && !hasNativeBlurFlag(window)) {
+                cancelPendingNativeBlurCleanup(nativeState)
+                clearNativeBlurReady(nativeState)
                 return
             }
 
             constrainImeWindowToKeyboardBounds(service, window, inputView)
+            if (allowDelayedNativeCleanup && scheduleNativeBlurCleanupIfReady(service, window, inputView, nativeState, generation)) {
+                Log.i(TAG, "Frosted glass disabled. Scheduled native blur cleanup.")
+                return
+            }
+
+            cancelPendingNativeBlurCleanup(nativeState)
+            clearNativeBlurReady(nativeState)
+            windowsWithAppliedFrostedGlass.remove(window)
             val nativeBlurChanged = applyDefaultBlur(service, window, false)
             if (Build.MANUFACTURER.equals("samsung", ignoreCase = true) || overrideMode == "force_samsung") {
                 applySamsungSemBlur(window, inputView, false)
@@ -229,6 +264,8 @@ object FrostedGlassHelper {
         val shouldUseSolidFallback = overrideMode == "force_solid" || !blurAvailable
 
         if (shouldUseSolidFallback) {
+            cancelPendingNativeBlurCleanup(nativeState)
+            clearNativeBlurReady(nativeState)
             val nativeBlurChanged = applyDefaultBlur(service, window, false, solidFallbackColor(service))
             if (Build.MANUFACTURER.equals("samsung", ignoreCase = true) || overrideMode == "force_samsung") {
                 clearSamsungSemBlur(samsungBlurTarget(inputView))
@@ -245,11 +282,13 @@ object FrostedGlassHelper {
         when (overrideMode) {
             "force_native" -> {
                 restoreFrostedThemeBackground(service, inputView)
-                if (applyDefaultBlur(service, window, true)) {
-                    Log.i(TAG, "OVERRIDE: Force Native Android Blur applied successfully via window.setBackgroundBlurRadius.")
+                if (applyNativeBlur(service, window, inputView, nativeState, generation)) {
+                    Log.i(TAG, "OVERRIDE: Force Native Android Blur requested via window.setBackgroundBlurRadius.")
                 }
             }
             "force_samsung" -> {
+                cancelPendingNativeBlurCleanup(nativeState)
+                clearNativeBlurReady(nativeState)
                 applySamsungSemBlur(window, inputView, true)
                 Log.i(TAG, "OVERRIDE: Force Samsung Proprietary Blur applied successfully via SemBlurInfo.")
             }
@@ -257,9 +296,13 @@ object FrostedGlassHelper {
                 // "auto" mode - The existing logic
                 if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        cancelPendingNativeBlurCleanup(nativeState)
+                        clearNativeBlurReady(nativeState)
                         applySamsungSemBlur(window, inputView, true)
                         Log.i(TAG, "AUTO: Samsung device detected (SDK >= S). Applied SemBlurInfo successfully.")
                     } else {
+                        cancelPendingNativeBlurCleanup(nativeState)
+                        clearNativeBlurReady(nativeState)
                         restoreFrostedThemeBackground(service, inputView)
                         val nativeBlurChanged = applyDefaultBlur(service, window, true)
                         applySamsungLegacyBlur(window, true)
@@ -269,8 +312,8 @@ object FrostedGlassHelper {
                     }
                 } else {
                     restoreFrostedThemeBackground(service, inputView)
-                    if (applyDefaultBlur(service, window, true)) {
-                        Log.i(TAG, "AUTO: Non-Samsung device detected. Applied Native Android window blur successfully.")
+                    if (applyNativeBlur(service, window, inputView, nativeState, generation)) {
+                        Log.i(TAG, "AUTO: Non-Samsung device detected. Requested Native Android window blur.")
                     }
                 }
             }
@@ -314,11 +357,13 @@ object FrostedGlassHelper {
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(0)
+            val params = window.attributes
+            if (params.blurBehindRadius != 0) {
+                params.setBlurBehindRadius(0)
+                window.attributes = params
+            }
         }
         window.setBackgroundDrawable(roundedWindowBackground(context, Color.TRANSPARENT))
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
         defaultBlurStates.remove(window)
         inputView?.setBackgroundColor(Color.TRANSPARENT)
 
@@ -432,37 +477,200 @@ object FrostedGlassHelper {
             return false
         }
 
+        // AOSP background blur reads its corner radius from a uniform round-rect outline.
+        // Per-corner radii produce a path outline, which native background blur treats as radius 0.
         window.setBackgroundDrawable(
             roundedWindowBackground(
                 service,
-                backgroundColor
+                backgroundColor,
+                topOnlyCorners = !enable
             )
         )
 
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
-
-        window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+        var layoutParamsChanged = false
+        val params = window.attributes
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             window.setBackgroundBlurRadius(targetRadius)
             Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+
+            val blurFlag = WindowManager.LayoutParams.FLAG_BLUR_BEHIND
+            if ((params.flags and blurFlag) != 0) {
+                params.flags = params.flags and blurFlag.inv()
+                layoutParamsChanged = true
+            }
+            if (params.blurBehindRadius != 0) {
+                params.setBlurBehindRadius(0)
+                layoutParamsChanged = true
+            }
+        }
+        if (layoutParamsChanged) {
+            window.attributes = params
         }
 
         defaultBlurStates[window] = desiredState
         return true
     }
 
-    private fun roundedWindowBackground(context: Context, color: Int): GradientDrawable {
+    private fun applyNativeBlur(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int
+    ): Boolean {
+        val cornerRadiusPx = keyboardCornerRadiusPx(service)
+        val targetBlurRadius = blurRadius(service)
+        if (reuseReadyNativeBlurIfPossible(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)) {
+            Log.d(TAG, "Kept active native blur for the same window state.")
+            return false
+        }
+
+        cancelPendingNativeBlurCleanup(nativeState)
+        clearNativeBlurReady(nativeState)
+        applyDefaultBlur(service, window, false)
+        scheduleNativeBlurEnable(service, window, inputView, nativeState, generation, cornerRadiusPx, targetBlurRadius)
+        return true
+    }
+
+    private fun scheduleNativeBlurEnable(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        val decorView = window.decorView
+        // Post activation so AOSP samples the uniform background outline during the next predraw.
+        decorView.post {
+            if (generation != nativeState.generation || !isFrostedTheme(service)) return@post
+            applyDefaultBlur(service, window, true)
+            markNativeBlurReady(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)
+            Log.d(TAG, "Native Android window blur enabled via window.setBackgroundBlurRadius.")
+            samsungBlurTarget(inputView)?.invalidateOutline()
+            inputView?.invalidate()
+            decorView.invalidate()
+        }
+    }
+
+    private fun scheduleNativeBlurCleanupIfReady(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int
+    ): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+        if (!canReuseNativeBlur(window, inputView, nativeState, keyboardCornerRadiusPx(service), blurRadius(service))) return false
+
+        cancelPendingNativeBlurCleanup(nativeState)
+        val decorView = window.decorView
+        val cleanup = Runnable {
+            nativeState.pendingCleanup = null
+            nativeState.pendingCleanupDecorView = null
+            if (generation != nativeState.generation) return@Runnable
+            applyDefaultBlur(service, window, false)
+            clearNativeBlurReady(nativeState)
+            windowsWithAppliedFrostedGlass.remove(window)
+            samsungBlurTarget(inputView)?.invalidateOutline()
+            inputView?.invalidate()
+            decorView.invalidate()
+            Log.d(TAG, "Delayed native blur cleanup completed.")
+        }
+        nativeState.pendingCleanup = cleanup
+        nativeState.pendingCleanupDecorView = decorView
+        decorView.postDelayed(cleanup, NATIVE_BLUR_HIDE_CLEANUP_DELAY_MS)
+        return true
+    }
+
+    private fun reuseReadyNativeBlurIfPossible(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ): Boolean {
+        if (!canReuseNativeBlur(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)) return false
+        cancelPendingNativeBlurCleanup(nativeState)
+        samsungBlurTarget(inputView)?.invalidateOutline()
+        inputView?.invalidate()
+        window.decorView.invalidate()
+        return true
+    }
+
+    private fun canReuseNativeBlur(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ): Boolean {
+        return nativeState.ready &&
+                nativeState.decorView === window.decorView &&
+                nativeState.inputView === inputView &&
+                nativeState.cornerRadiusPx == cornerRadiusPx &&
+                nativeState.blurRadius == targetBlurRadius
+    }
+
+    private fun markNativeBlurReady(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ) {
+        nativeState.ready = true
+        nativeState.decorView = window.decorView
+        nativeState.inputView = inputView
+        nativeState.cornerRadiusPx = cornerRadiusPx
+        nativeState.blurRadius = targetBlurRadius
+    }
+
+    private fun clearNativeBlurReady(nativeState: NativeBlurState) {
+        nativeState.ready = false
+        nativeState.decorView = null
+        nativeState.inputView = null
+        nativeState.cornerRadiusPx = -1f
+        nativeState.blurRadius = -1
+    }
+
+    private fun cancelPendingNativeBlurCleanup(nativeState: NativeBlurState) {
+        val cleanup = nativeState.pendingCleanup
+        val decorView = nativeState.pendingCleanupDecorView
+        if (cleanup != null && decorView != null) {
+            decorView.removeCallbacks(cleanup)
+        }
+        nativeState.pendingCleanup = null
+        nativeState.pendingCleanupDecorView = null
+    }
+
+    private fun nativeBlurState(window: Window): NativeBlurState {
+        return synchronized(nativeBlurStates) {
+            nativeBlurStates.getOrPut(window) { NativeBlurState() }
+        }
+    }
+
+    private fun roundedWindowBackground(
+        context: Context,
+        color: Int,
+        topOnlyCorners: Boolean = true
+    ): GradientDrawable {
         val radiusPx = keyboardCornerRadiusPx(context)
         return GradientDrawable().apply {
             setColor(color)
-            cornerRadii = floatArrayOf(
-                radiusPx, radiusPx,
-                radiusPx, radiusPx,
-                0f, 0f,
-                0f, 0f
-            )
+            if (topOnlyCorners) {
+                cornerRadii = floatArrayOf(
+                    radiusPx, radiusPx,
+                    radiusPx, radiusPx,
+                    0f, 0f,
+                    0f, 0f
+                )
+            } else {
+                // Uniform radius lets AOSP pass a non-zero corner radius to BackgroundBlurDrawable.
+                setCornerRadius(radiusPx)
+            }
         }
     }
 
@@ -498,9 +706,6 @@ object FrostedGlassHelper {
     private fun applySolidFallbackBackground(context: Context, window: Window, inputView: View?) {
         val color = solidFallbackColor(context)
         window.setBackgroundDrawable(roundedWindowBackground(context, color))
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
         inputView?.setBackgroundColor(Color.TRANSPARENT)
         samsungBlurTarget(inputView)?.let { target ->
             target.setBackgroundColor(color)

--- a/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
+++ b/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
@@ -312,7 +312,9 @@ object FrostedGlassHelper {
         Log.d(TAG, "Samsung SDK ${Build.VERSION.SDK_INT}: using SemBlurInfo path; enable=$enable")
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-        window.setBackgroundBlurRadius(0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            window.setBackgroundBlurRadius(0)
+        }
         window.setBackgroundDrawable(roundedWindowBackground(context, Color.TRANSPARENT))
         val decorView = window.decorView
         decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
@@ -442,8 +444,10 @@ object FrostedGlassHelper {
         decorView.clipToOutline = true
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
-        window.setBackgroundBlurRadius(targetRadius)
-        Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            window.setBackgroundBlurRadius(targetRadius)
+            Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+        }
 
         defaultBlurStates[window] = desiredState
         return true
@@ -518,6 +522,7 @@ object FrostedGlassHelper {
     }
 
     private fun isSystemBlurAvailable(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
         if (isBatterySaverMode(context)) return false
         return try {
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager

--- a/app/src/main/java/helium314/keyboard/latin/RoundedKeyboardFrameView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/RoundedKeyboardFrameView.kt
@@ -5,10 +5,13 @@ package helium314.keyboard.latin
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Outline
 import android.graphics.Path
 import android.graphics.RectF
 import android.os.Build
 import android.util.AttributeSet
+import android.view.View
+import android.view.ViewOutlineProvider
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
@@ -24,6 +27,7 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
     private val clipPath = Path()
+    private val outlineClipPath = Path()
     private val clipRect = RectF()
     private var lastWidth = -1
     private var lastHeight = -1
@@ -34,7 +38,35 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
     private val prefListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         if (key == Settings.PREF_KEYBOARD_CORNER_RADIUS) {
             cachedRadiusPx = -1f
+            invalidateOutline()
             postInvalidate()
+        }
+    }
+
+    init {
+        // Also clip via HWUI so hardware-layered descendants respect the rounded keyboard shape.
+        // Android 13+ supports path outlines, which lets us keep only the top corners rounded.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            outlineProvider = object : ViewOutlineProvider() {
+                override fun getOutline(view: View, outline: Outline) {
+                    val radiusPx = if (cachedRadiusPx >= 0f) cachedRadiusPx else keyboardCornerRadiusPx()
+                    if (view.width <= 0 || view.height <= 0 || radiusPx <= 0f) {
+                        outline.setRect(0, 0, view.width, view.height)
+                        return
+                    }
+                    outlineClipPath.reset()
+                    outlineClipPath.addRoundRect(
+                        0f,
+                        0f,
+                        view.width.toFloat(),
+                        view.height.toFloat(),
+                        floatArrayOf(radiusPx, radiusPx, radiusPx, radiusPx, 0f, 0f, 0f, 0f),
+                        Path.Direction.CW
+                    )
+                    outline.setPath(outlineClipPath)
+                }
+            }
+            clipToOutline = true
         }
     }
 
@@ -42,12 +74,22 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
         super.onAttachedToWindow()
         context.prefs().registerOnSharedPreferenceChangeListener(prefListener)
         cachedRadiusPx = -1f
+        invalidateOutline()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         context.prefs().unregisterOnSharedPreferenceChangeListener(prefListener)
         staticDustOverlay.clear()
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        // Rebuild outline as soon as the IME view gets its real size.
+        lastWidth = -1
+        lastHeight = -1
+        invalidateOutline()
+        postInvalidateOnAnimation()
     }
 
     override fun draw(canvas: Canvas) {

--- a/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/suggestions/SuggestionStripView.kt
@@ -74,6 +74,7 @@ import helium314.keyboard.latin.utils.pinToolbarKeyAt
 import helium314.keyboard.latin.utils.prefs
 import helium314.keyboard.latin.utils.removeFirst
 import helium314.keyboard.latin.utils.setToolbarButtonsActivatedStateOnPrefChange
+import helium314.keyboard.latin.utils.startDragAndDropCompat
 import helium314.keyboard.latin.utils.updateToolbarButtonActivatedState
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
@@ -609,8 +610,16 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
         val toolbarMode = Settings.getValues().mToolbarMode
         val allowPinnedKeys = toolbarMode == ToolbarMode.EXPANDABLE || toolbarMode == ToolbarMode.TOOLBAR_KEYS
         val allowSuggestions = toolbarMode == ToolbarMode.EXPANDABLE || toolbarMode == ToolbarMode.SUGGESTION_STRIP
+        val isFieldEmpty = isTextFieldEmpty()
+        // Keep empty-editor ownership stable when beginning-of-sentence predictions arrive asynchronously.
+        val showPinnedKeysForEmptyField = showSuggestions &&
+                allowPinnedKeys &&
+                !isExternalSuggestionVisible &&
+                isFieldEmpty &&
+                pinnedKeys.childCount > 0
         val showSuggestionContent = showSuggestions && allowSuggestions &&
-                (isExternalSuggestionVisible || shouldShowSuggestionContent())
+                !showPinnedKeysForEmptyField &&
+                (isExternalSuggestionVisible || !isFieldEmpty || shouldShowSuggestionContent())
         val showChips = showSuggestionContent && !isExternalSuggestionVisible && shouldUseChipSuggestions()
         suggestionsStrip.isVisible = showSuggestionContent && !showChips
         suggestionsChipScroll.isVisible = showChips
@@ -845,7 +854,11 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
     private fun startPinnedToolbarDrag(view: View, key: ToolbarKey) {
         val clipData = ClipData.newPlainText(TOOLBAR_DRAG_CLIP_LABEL, key.name)
         view.visibility = INVISIBLE
-        view.startDragAndDrop(clipData, DragShadowBuilder(view), ToolbarDragState(key, ToolbarDragSource.PINNED_ROW, view), 0)
+        view.startDragAndDropCompat(
+            clipData,
+            DragShadowBuilder(view),
+            ToolbarDragState(key, ToolbarDragSource.PINNED_ROW, view),
+        )
     }
 
     private fun applyToolbarPillBackground(view: ImageButton, colors: Colors) {
@@ -924,6 +937,23 @@ class SuggestionStripView(context: Context, attrs: AttributeSet?, defStyle: Int)
         applyAlphabetIconTint(accessPointTriggerBtn, colors)
         applySuggestionStripButtonIconSizing(accessPointTriggerBtn)
         updateSuggestionContainersVisibility(true)
+    }
+
+    private fun isTextFieldEmpty(): Boolean {
+        val ime = getLatinIME() ?: return true
+        val connection = ime.currentInputConnection ?: return true
+        val before = connection.getTextBeforeCursor(1, 0)
+        val after = connection.getTextAfterCursor(1, 0)
+        return (before == null || before.isEmpty()) && (after == null || after.isEmpty())
+    }
+
+    private fun getLatinIME(): helium314.keyboard.latin.LatinIME? {
+        var ctx = context
+        while (ctx is android.content.ContextWrapper) {
+            if (ctx is helium314.keyboard.latin.LatinIME) return ctx
+            ctx = ctx.baseContext
+        }
+        return ctx as? helium314.keyboard.latin.LatinIME
     }
 
     companion object {

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -4,7 +4,9 @@ package helium314.keyboard.latin.utils
 import android.content.Context
 import android.content.ClipData
 import android.content.SharedPreferences
+import android.os.Build
 import android.view.View
+import android.view.View.DragShadowBuilder
 import android.view.ViewGroup
 import android.widget.ImageButton
 import android.widget.ImageView
@@ -36,6 +38,18 @@ data class ToolbarDragState(
     val source: ToolbarDragSource,
     val sourceView: View? = null,
 )
+
+@Suppress("DEPRECATION")
+fun View.startDragAndDropCompat(
+    clipData: ClipData,
+    shadowBuilder: DragShadowBuilder,
+    localState: Any?,
+    flags: Int = 0,
+): Boolean = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    startDragAndDrop(clipData, shadowBuilder, localState, flags)
+} else {
+    startDrag(clipData, shadowBuilder, localState, flags)
+}
 
 fun createToolbarKey(context: Context, key: ToolbarKey): ImageButton {
     val button = ImageButton(context, null, R.attr.suggestionWordStyle)


### PR DESCRIPTION
## Summary

This PR fixes square corners in the AOSP/native frosted-glass blur path.

KBoard's keyboard surface normally has only the top corners rounded, with the bottom edge sitting flush against the bottom of the screen. That is the right shape for drawing and clipping the keyboard content, but it is not the shape AOSP's native blur code needs in order to compute rounded blur corners. Android reads the outline of the window background drawable, and for the native background blur radius it only accepts a rounded-rectangle outline.

To satisfy that AOSP requirement, this PR uses a uniform rounded-rectangle window background while native blur is enabled. When native blur is disabled, or when KBoard falls back to a solid/non-blur background, the window background returns to the normal top-only shape.

The tradeoff is that the native blur layer has all four corners rounded while native blur is active. In practice, that should usually be acceptable: most modern devices have rounded screen corners, and the keyboard sits flush with the bottom of the screen, so the keyboard's bottom corners usually are not visible anyway. The keyboard content itself is still clipped to the intended top-only shape by `RoundedKeyboardFrameView`.

The remaining changes make that fix visually stable. Native blur enablement is deferred through the `DecorView` so Android creates/updates the internal blur drawable with the corrected background outline, and short hide/show sequences reuse the already-correct blur state instead of briefly tearing it down and recreating it.

---

## Background: why `clipToOutline` is not enough

The existing implementation tries to solve the corner issue by setting the `DecorView` outline provider to the background and enabling `clipToOutline`. That is a reasonable approach for View content clipping, but AOSP computes native background blur corners through a different path.

`DecorView.updateBackgroundBlurCorners()` asks the original window background drawable for its outline, then only forwards a radius to the blur drawable if that outline is `MODE_ROUND_RECT`:

> [`DecorView.java:1328`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/core/java/com/android/internal/policy/DecorView.java#1328)

So for native blur corners, the important input is the outline mode returned by the window background drawable. `DecorView.clipToOutline` may clip rendered View contents, but it does not change the value used by this blur-corner calculation.

KBoard's normal top-only background uses per-corner `GradientDrawable` radii. In AOSP, that path makes `GradientDrawable.getOutline()` build a path and call `Outline.setPath()`:

> [`GradientDrawable.java:1954`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/drawable/GradientDrawable.java#1954)
> [`Outline.java:309`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/Outline.java#309)

That gives AOSP `Outline.MODE_PATH`, not `Outline.MODE_ROUND_RECT`, so `DecorView.updateBackgroundBlurCorners()` falls back to radius `0`. The result is square native blur corners even though the keyboard content can still be clipped correctly.

---

## What this PR changes

For the AOSP/native blur path, the window background now switches shape based on whether native blur is active.

When native blur is enabled, KBoard uses a uniform radius:

```kotlin
GradientDrawable().apply {
    setColor(backgroundColor)
    setCornerRadius(radiusPx)
}
```

`GradientDrawable.GradientState#setCornerRadius()` stores a single radius and clears the per-corner radius array:

> [`GradientDrawable.java:2349`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/drawable/GradientDrawable.java#2349)

With no per-corner radius array, `GradientDrawable.getOutline()` emits a rounded rectangle, calling `Outline.setRoundRect()`:

> [`GradientDrawable.java:1966`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/drawable/GradientDrawable.java#1966)
> [`Outline.java:202`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/Outline.java#202)

That satisfies AOSP's `MODE_ROUND_RECT` check, so Android passes the configured keyboard corner radius to the native background blur drawable instead of using `0`.

When native blur is not active, KBoard keeps the existing top-only per-corner background. This keeps the all-four-corners shape limited to the native blur case where AOSP requires it.

Keyboard content clipping stays in `RoundedKeyboardFrameView`, which represents the actual keyboard surface and can preserve the top-only rounded shape. On Android 13+, it now also exposes a path outline so hardware-layered descendants respect that same top-only clip; `Outline.canClip()` documents that all outline shapes support clipping only as of API 33; older versions continue using the existing canvas clipping behavior:

> [`Outline.java:121`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/graphics/java/android/graphics/Outline.java#121)

---

## Timing and quick hide/show handling

The shape change above fixes the AOSP blur-corner calculation, but there are two timing details to handle.

First, AOSP updates the internal blur drawable's corner radius from a predraw listener (`updateBackgroundBlurCorners()` runs from `DecorView`'s `ViewTreeObserver.OnPreDrawListener`):

> [`DecorView.java:282`](https://android.googlesource.com/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168/core/java/com/android/internal/policy/DecorView.java#282)

If `setBackgroundBlurRadius(...)` runs while the IME window is still going through its initial setup, the first visible blur frame can appear before that predraw update has sampled the corrected rounded-rect background outline.

To avoid that race, the native path is staged in two steps: first clear native blur and leave the non-blur/top-only background installed, then post the native blur application to the `DecorView`. The posted step installs the uniform rounded-rect blur background and calls `setBackgroundBlurRadius(...)` after the initial window setup/layout work.

Second, quick hide/show sequences should not force AOSP to tear down and recreate the native blur drawable. Predictive-back cancellation can begin hiding the IME and then show it again almost immediately. If blur is cleared immediately during that hide, AOSP removes its internal blur drawable; the next show has to recreate it and re-enter the predraw update path, which can look like a brief off/on flicker.

To avoid that, the helper tracks native blur readiness per `Window`. Once blur has successfully been enabled after layout, it records the known-good state: the `DecorView`, input view, keyboard corner radius, blur radius, generation, and any pending cleanup runnable.

On hide, if the current state still matches, cleanup is delayed briefly instead of clearing blur immediately. If the IME is shown again with the same state before that cleanup runs, the cleanup is cancelled and the already-correct blur state is reused.

Resize-overlay suppression still clears immediately, because that path needs blur suppressed right away while the resize overlay is visible.