### PR TITLE
fix(blur): round native AOSP background-blur corners.

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
+++ b/app/src/main/java/helium314/keyboard/latin/FrostedGlassHelper.kt
@@ -8,7 +8,6 @@ import android.os.Build
 import android.util.Log
 import android.view.Gravity
 import android.view.View
-import android.view.ViewOutlineProvider
 import android.view.Window
 import android.view.WindowManager
 import helium314.keyboard.latin.common.ColorType
@@ -31,6 +30,7 @@ object FrostedGlassHelper {
 
     private const val TAG = "KBoardBlur"
     private const val SAMSUNG_EXTENSION_FLAG_BLUR = 0x10
+    private const val NATIVE_BLUR_HIDE_CLEANUP_DELAY_MS = 250L
     private val failedSamsungSemBlurModes = mutableSetOf<String>()
     private val windowsWithAppliedFrostedGlass: MutableSet<Window> =
         Collections.newSetFromMap(WeakHashMap<Window, Boolean>())
@@ -38,6 +38,8 @@ object FrostedGlassHelper {
         Collections.newSetFromMap(WeakHashMap<Window, Boolean>())
     private val defaultBlurStates: MutableMap<Window, DefaultBlurState> =
         Collections.synchronizedMap(WeakHashMap<Window, DefaultBlurState>())
+    private val nativeBlurStates: MutableMap<Window, NativeBlurState> =
+        Collections.synchronizedMap(WeakHashMap<Window, NativeBlurState>())
 
     private data class DefaultBlurState(
         val enabled: Boolean,
@@ -46,6 +48,17 @@ object FrostedGlassHelper {
         val backgroundBlurOnly: Boolean,
         val cornerRadiusPx: Float
     )
+
+    private class NativeBlurState {
+        var generation = 0
+        var ready = false
+        var decorView: View? = null
+        var inputView: View? = null
+        var cornerRadiusPx = -1f
+        var blurRadius = -1
+        var pendingCleanup: Runnable? = null
+        var pendingCleanupDecorView: View? = null
+    }
 
     // =========================================================================
     // LAZY STATICS: Pre-resolve reflection references ONCE and cache them forever
@@ -189,30 +202,52 @@ object FrostedGlassHelper {
         val window = service.window?.window ?: return
         if (suppressed) {
             windowsWithResizeOverlayBlurSuppressed.add(window)
-            configureFrostedGlass(service, inputView, false)
+            configureFrostedGlassInternal(service, inputView, false, allowDelayedNativeCleanup = false)
         } else {
             windowsWithResizeOverlayBlurSuppressed.remove(window)
-            configureFrostedGlass(service, inputView, restoreEnabled)
+            configureFrostedGlassInternal(service, inputView, restoreEnabled, allowDelayedNativeCleanup = true)
         }
     }
 
     @JvmStatic
     fun configureFrostedGlass(service: InputMethodService, inputView: View?, enable: Boolean) {
+        configureFrostedGlassInternal(service, inputView, enable, allowDelayedNativeCleanup = true)
+    }
+
+    private fun configureFrostedGlassInternal(
+        service: InputMethodService,
+        inputView: View?,
+        enable: Boolean,
+        allowDelayedNativeCleanup: Boolean
+    ) {
         val window = service.window?.window ?: return
+        val nativeState = nativeBlurState(window)
+        val generation = ++nativeState.generation
         val overrideMode = service.prefs().getString(Settings.PREF_BLUR_RENDER_OVERRIDE, "auto")
 
         if (enable && windowsWithResizeOverlayBlurSuppressed.contains(window)) {
-            configureFrostedGlass(service, inputView, false)
+            configureFrostedGlassInternal(service, inputView, false, allowDelayedNativeCleanup = false)
             return
         }
 
         if (!enable) {
-            val hadAppliedFrostedGlass = windowsWithAppliedFrostedGlass.remove(window)
-            if (!hadAppliedFrostedGlass && !hasNativeBlurFlag(window)) {
+            val hadAppliedFrostedGlass = windowsWithAppliedFrostedGlass.contains(window)
+            val hadDefaultBlurEnabled = defaultBlurStates[window]?.enabled == true
+            if (!hadAppliedFrostedGlass && !hadDefaultBlurEnabled && !hasNativeBlurFlag(window)) {
+                cancelPendingNativeBlurCleanup(nativeState)
+                clearNativeBlurReady(nativeState)
                 return
             }
 
             constrainImeWindowToKeyboardBounds(service, window, inputView)
+            if (allowDelayedNativeCleanup && scheduleNativeBlurCleanupIfReady(service, window, inputView, nativeState, generation)) {
+                Log.i(TAG, "Frosted glass disabled. Scheduled native blur cleanup.")
+                return
+            }
+
+            cancelPendingNativeBlurCleanup(nativeState)
+            clearNativeBlurReady(nativeState)
+            windowsWithAppliedFrostedGlass.remove(window)
             val nativeBlurChanged = applyDefaultBlur(service, window, false)
             if (Build.MANUFACTURER.equals("samsung", ignoreCase = true) || overrideMode == "force_samsung") {
                 applySamsungSemBlur(window, inputView, false)
@@ -229,6 +264,8 @@ object FrostedGlassHelper {
         val shouldUseSolidFallback = overrideMode == "force_solid" || !blurAvailable
 
         if (shouldUseSolidFallback) {
+            cancelPendingNativeBlurCleanup(nativeState)
+            clearNativeBlurReady(nativeState)
             val nativeBlurChanged = applyDefaultBlur(service, window, false, solidFallbackColor(service))
             if (Build.MANUFACTURER.equals("samsung", ignoreCase = true) || overrideMode == "force_samsung") {
                 clearSamsungSemBlur(samsungBlurTarget(inputView))
@@ -245,11 +282,13 @@ object FrostedGlassHelper {
         when (overrideMode) {
             "force_native" -> {
                 restoreFrostedThemeBackground(service, inputView)
-                if (applyDefaultBlur(service, window, true)) {
-                    Log.i(TAG, "OVERRIDE: Force Native Android Blur applied successfully via window.setBackgroundBlurRadius.")
+                if (applyNativeBlur(service, window, inputView, nativeState, generation)) {
+                    Log.i(TAG, "OVERRIDE: Force Native Android Blur requested via window.setBackgroundBlurRadius.")
                 }
             }
             "force_samsung" -> {
+                cancelPendingNativeBlurCleanup(nativeState)
+                clearNativeBlurReady(nativeState)
                 applySamsungSemBlur(window, inputView, true)
                 Log.i(TAG, "OVERRIDE: Force Samsung Proprietary Blur applied successfully via SemBlurInfo.")
             }
@@ -257,9 +296,13 @@ object FrostedGlassHelper {
                 // "auto" mode - The existing logic
                 if (Build.MANUFACTURER.equals("samsung", ignoreCase = true)) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        cancelPendingNativeBlurCleanup(nativeState)
+                        clearNativeBlurReady(nativeState)
                         applySamsungSemBlur(window, inputView, true)
                         Log.i(TAG, "AUTO: Samsung device detected (SDK >= S). Applied SemBlurInfo successfully.")
                     } else {
+                        cancelPendingNativeBlurCleanup(nativeState)
+                        clearNativeBlurReady(nativeState)
                         restoreFrostedThemeBackground(service, inputView)
                         val nativeBlurChanged = applyDefaultBlur(service, window, true)
                         applySamsungLegacyBlur(window, true)
@@ -269,8 +312,8 @@ object FrostedGlassHelper {
                     }
                 } else {
                     restoreFrostedThemeBackground(service, inputView)
-                    if (applyDefaultBlur(service, window, true)) {
-                        Log.i(TAG, "AUTO: Non-Samsung device detected. Applied Native Android window blur successfully.")
+                    if (applyNativeBlur(service, window, inputView, nativeState, generation)) {
+                        Log.i(TAG, "AUTO: Non-Samsung device detected. Requested Native Android window blur.")
                     }
                 }
             }
@@ -313,10 +356,12 @@ object FrostedGlassHelper {
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
         window.setBackgroundBlurRadius(0)
+        val params = window.attributes
+        if (params.blurBehindRadius != 0) {
+            params.setBlurBehindRadius(0)
+            window.attributes = params
+        }
         window.setBackgroundDrawable(roundedWindowBackground(context, Color.TRANSPARENT))
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
         defaultBlurStates.remove(window)
         inputView?.setBackgroundColor(Color.TRANSPARENT)
 
@@ -430,35 +475,198 @@ object FrostedGlassHelper {
             return false
         }
 
+        // AOSP background blur reads its corner radius from a uniform round-rect outline.
+        // Per-corner radii produce a path outline, which native background blur treats as radius 0.
         window.setBackgroundDrawable(
             roundedWindowBackground(
                 service,
-                backgroundColor
+                backgroundColor,
+                topOnlyCorners = !enable
             )
         )
 
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
-
-        window.clearFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND)
+        var layoutParamsChanged = false
+        val params = window.attributes
         window.setBackgroundBlurRadius(targetRadius)
         Log.d(TAG, "window.setBackgroundBlurRadius successfully called without throwing an exception.")
+
+        val blurFlag = WindowManager.LayoutParams.FLAG_BLUR_BEHIND
+        if ((params.flags and blurFlag) != 0) {
+            params.flags = params.flags and blurFlag.inv()
+            layoutParamsChanged = true
+        }
+        if (params.blurBehindRadius != 0) {
+            params.setBlurBehindRadius(0)
+            layoutParamsChanged = true
+        }
+        if (layoutParamsChanged) {
+            window.attributes = params
+        }
 
         defaultBlurStates[window] = desiredState
         return true
     }
 
-    private fun roundedWindowBackground(context: Context, color: Int): GradientDrawable {
+    private fun applyNativeBlur(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int
+    ): Boolean {
+        val cornerRadiusPx = keyboardCornerRadiusPx(service)
+        val targetBlurRadius = blurRadius(service)
+        if (reuseReadyNativeBlurIfPossible(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)) {
+            Log.d(TAG, "Kept active native blur for the same window state.")
+            return false
+        }
+
+        cancelPendingNativeBlurCleanup(nativeState)
+        clearNativeBlurReady(nativeState)
+        applyDefaultBlur(service, window, false)
+        scheduleNativeBlurEnable(service, window, inputView, nativeState, generation, cornerRadiusPx, targetBlurRadius)
+        return true
+    }
+
+    private fun scheduleNativeBlurEnable(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        val decorView = window.decorView
+        // Post activation so AOSP samples the uniform background outline during the next predraw.
+        decorView.post {
+            if (generation != nativeState.generation || !isFrostedTheme(service)) return@post
+            applyDefaultBlur(service, window, true)
+            markNativeBlurReady(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)
+            Log.d(TAG, "Native Android window blur enabled via window.setBackgroundBlurRadius.")
+            samsungBlurTarget(inputView)?.invalidateOutline()
+            inputView?.invalidate()
+            decorView.invalidate()
+        }
+    }
+
+    private fun scheduleNativeBlurCleanupIfReady(
+        service: InputMethodService,
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        generation: Int
+    ): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+        if (!canReuseNativeBlur(window, inputView, nativeState, keyboardCornerRadiusPx(service), blurRadius(service))) return false
+
+        cancelPendingNativeBlurCleanup(nativeState)
+        val decorView = window.decorView
+        val cleanup = Runnable {
+            nativeState.pendingCleanup = null
+            nativeState.pendingCleanupDecorView = null
+            if (generation != nativeState.generation) return@Runnable
+            applyDefaultBlur(service, window, false)
+            clearNativeBlurReady(nativeState)
+            windowsWithAppliedFrostedGlass.remove(window)
+            samsungBlurTarget(inputView)?.invalidateOutline()
+            inputView?.invalidate()
+            decorView.invalidate()
+            Log.d(TAG, "Delayed native blur cleanup completed.")
+        }
+        nativeState.pendingCleanup = cleanup
+        nativeState.pendingCleanupDecorView = decorView
+        decorView.postDelayed(cleanup, NATIVE_BLUR_HIDE_CLEANUP_DELAY_MS)
+        return true
+    }
+
+    private fun reuseReadyNativeBlurIfPossible(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ): Boolean {
+        if (!canReuseNativeBlur(window, inputView, nativeState, cornerRadiusPx, targetBlurRadius)) return false
+        cancelPendingNativeBlurCleanup(nativeState)
+        samsungBlurTarget(inputView)?.invalidateOutline()
+        inputView?.invalidate()
+        window.decorView.invalidate()
+        return true
+    }
+
+    private fun canReuseNativeBlur(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ): Boolean {
+        return nativeState.ready &&
+                nativeState.decorView === window.decorView &&
+                nativeState.inputView === inputView &&
+                nativeState.cornerRadiusPx == cornerRadiusPx &&
+                nativeState.blurRadius == targetBlurRadius
+    }
+
+    private fun markNativeBlurReady(
+        window: Window,
+        inputView: View?,
+        nativeState: NativeBlurState,
+        cornerRadiusPx: Float,
+        targetBlurRadius: Int
+    ) {
+        nativeState.ready = true
+        nativeState.decorView = window.decorView
+        nativeState.inputView = inputView
+        nativeState.cornerRadiusPx = cornerRadiusPx
+        nativeState.blurRadius = targetBlurRadius
+    }
+
+    private fun clearNativeBlurReady(nativeState: NativeBlurState) {
+        nativeState.ready = false
+        nativeState.decorView = null
+        nativeState.inputView = null
+        nativeState.cornerRadiusPx = -1f
+        nativeState.blurRadius = -1
+    }
+
+    private fun cancelPendingNativeBlurCleanup(nativeState: NativeBlurState) {
+        val cleanup = nativeState.pendingCleanup
+        val decorView = nativeState.pendingCleanupDecorView
+        if (cleanup != null && decorView != null) {
+            decorView.removeCallbacks(cleanup)
+        }
+        nativeState.pendingCleanup = null
+        nativeState.pendingCleanupDecorView = null
+    }
+
+    private fun nativeBlurState(window: Window): NativeBlurState {
+        return synchronized(nativeBlurStates) {
+            nativeBlurStates.getOrPut(window) { NativeBlurState() }
+        }
+    }
+
+    private fun roundedWindowBackground(
+        context: Context,
+        color: Int,
+        topOnlyCorners: Boolean = true
+    ): GradientDrawable {
         val radiusPx = keyboardCornerRadiusPx(context)
         return GradientDrawable().apply {
             setColor(color)
-            cornerRadii = floatArrayOf(
-                radiusPx, radiusPx,
-                radiusPx, radiusPx,
-                0f, 0f,
-                0f, 0f
-            )
+            if (topOnlyCorners) {
+                cornerRadii = floatArrayOf(
+                    radiusPx, radiusPx,
+                    radiusPx, radiusPx,
+                    0f, 0f,
+                    0f, 0f
+                )
+            } else {
+                // Uniform radius lets AOSP pass a non-zero corner radius to BackgroundBlurDrawable.
+                setCornerRadius(radiusPx)
+            }
         }
     }
 
@@ -494,9 +702,6 @@ object FrostedGlassHelper {
     private fun applySolidFallbackBackground(context: Context, window: Window, inputView: View?) {
         val color = solidFallbackColor(context)
         window.setBackgroundDrawable(roundedWindowBackground(context, color))
-        val decorView = window.decorView
-        decorView.outlineProvider = ViewOutlineProvider.BACKGROUND
-        decorView.clipToOutline = true
         inputView?.setBackgroundColor(Color.TRANSPARENT)
         samsungBlurTarget(inputView)?.let { target ->
             target.setBackgroundColor(color)

--- a/app/src/main/java/helium314/keyboard/latin/RoundedKeyboardFrameView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/RoundedKeyboardFrameView.kt
@@ -5,10 +5,13 @@ package helium314.keyboard.latin
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Outline
 import android.graphics.Path
 import android.graphics.RectF
 import android.os.Build
 import android.util.AttributeSet
+import android.view.View
+import android.view.ViewOutlineProvider
 import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
@@ -24,6 +27,7 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
     private val clipPath = Path()
+    private val outlineClipPath = Path()
     private val clipRect = RectF()
     private var lastWidth = -1
     private var lastHeight = -1
@@ -34,7 +38,35 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
     private val prefListener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         if (key == Settings.PREF_KEYBOARD_CORNER_RADIUS) {
             cachedRadiusPx = -1f
+            invalidateOutline()
             postInvalidate()
+        }
+    }
+
+    init {
+        // Also clip via HWUI so hardware-layered descendants respect the rounded keyboard shape.
+        // Android 13+ supports path outlines, which lets us keep only the top corners rounded.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            outlineProvider = object : ViewOutlineProvider() {
+                override fun getOutline(view: View, outline: Outline) {
+                    val radiusPx = if (cachedRadiusPx >= 0f) cachedRadiusPx else keyboardCornerRadiusPx()
+                    if (view.width <= 0 || view.height <= 0 || radiusPx <= 0f) {
+                        outline.setRect(0, 0, view.width, view.height)
+                        return
+                    }
+                    outlineClipPath.reset()
+                    outlineClipPath.addRoundRect(
+                        0f,
+                        0f,
+                        view.width.toFloat(),
+                        view.height.toFloat(),
+                        floatArrayOf(radiusPx, radiusPx, radiusPx, radiusPx, 0f, 0f, 0f, 0f),
+                        Path.Direction.CW
+                    )
+                    outline.setPath(outlineClipPath)
+                }
+            }
+            clipToOutline = true
         }
     }
 
@@ -42,12 +74,22 @@ class RoundedKeyboardFrameView @JvmOverloads constructor(
         super.onAttachedToWindow()
         context.prefs().registerOnSharedPreferenceChangeListener(prefListener)
         cachedRadiusPx = -1f
+        invalidateOutline()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         context.prefs().unregisterOnSharedPreferenceChangeListener(prefListener)
         staticDustOverlay.clear()
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        // Rebuild outline as soon as the IME view gets its real size.
+        lastWidth = -1
+        lastHeight = -1
+        invalidateOutline()
+        postInvalidateOnAnimation()
     }
 
     override fun draw(canvas: Canvas) {


### PR DESCRIPTION
Supersedes PR #2.

This ports only the original rounded native-blur corner fix onto the current lag-free `main`.

Original implementation by [@tokenflood](https://github.com/tokenflood), with commit authorship preserved.

cc @tokenflood

## Tested on Pixel 6a

- Rounded native-blur corners
- Repeated hide/show
- Predictive-back cancellation
- Gesture and three-button navigation
- Corner-radius changes
- Typing performance with no lag